### PR TITLE
use cdnjs.cloudflare.com instead of ajax.googleapis.com

### DIFF
--- a/filemanager/templates/filemanager/index.html
+++ b/filemanager/templates/filemanager/index.html
@@ -18,7 +18,7 @@
 
     <!-- Angular JS -->
 
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.6/angular.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.6/angular.min.js"></script>
     <script src="{% static 'filemanager/js/fileManager.js' %}"></script>
 
     <!-- Fix for old browsers -->


### PR DESCRIPTION
googleapis is not accessable in China
cloudflare is accessable and faster in the most