### PR TITLE
 fix issue on installing some dedicated server

### DIFF
--- a/install-cn.sh
+++ b/install-cn.sh
@@ -4,6 +4,14 @@ rm -f /etc/yum.repos.d/epel.repo
 rm -f /etc/yum.repos.d/epel.repo.rpmsave
 yum install epel-release -y
 #some provider's centos7 template come with incorrect or misconfigured epel.repo
+if systemctl is-active named | grep -q 'active'; then
+  systemctl stop named
+  systemctl disable named
+  echo "Disabling named to aviod powerdns conflicts..."
+  else
+  echo "named is not installed or active, to next step..."
+fi
+# above if will check if server has named.service running that occupies port 53 which makes powerdns failed to start
 yum clean all
 yum update -y
 yum install wget which curl -y


### PR DESCRIPTION
fix issue on installing some dedicated server with pre-installed named.service occupies port 53 which makes powerdns failed to start