### PR TITLE
Bug fix: Mail Child domain A record and MX record

### DIFF
--- a/plogical/dnsUtilities.py
+++ b/plogical/dnsUtilities.py
@@ -439,9 +439,9 @@ class DNS:
 
                 DNS.createDNSRecord(zone, actualSubDomain, "A", ipAddress, 0, 3600)
 
-                ## Mail Record
+                ## Mail A Record
 
-                DNS.createDNSRecord(zone, 'mail.' + actualSubDomain, "A", ipAddress, 0, 3600)
+                DNS.createDNSRecord(zone, 'mail.' + topLevelDomain, "A", ipAddress, 0, 3600)
 
                 # CNAME Records.
 
@@ -451,7 +451,7 @@ class DNS:
 
                 ## MX Records
 
-                mxValue = "mail." + actualSubDomain
+                mxValue = "mail." + topLevelDomain
 
                 record = Records(domainOwner=zone,
                                  domain_id=zone.id,


### PR DESCRIPTION
Previously it would create mail.mail.example.com records. Now mail.example.com