### PR TITLE
Prevent non-logged in user from accessing endpoint

### DIFF
--- a/baseTemplate/views.py
+++ b/baseTemplate/views.py
@@ -66,6 +66,8 @@ def getAdminStatus(request):
 
 def getSystemStatus(request):
     try:
+        val = request.session['userID']
+        currentACL = ACLManager.loadedACL(val)
         HTTPData = SystemInformation.getSystemInformation()
         json_data = json.dumps(HTTPData)
         return HttpResponse(json_data)


### PR DESCRIPTION
Prevent non-logged in user from accessing endpoint https://hostname/ip:8090/base/getSystemStatus