### PR TITLE
Hide clients public IP and LAN IP

### DIFF
--- a/CPScripts/mailscanneruninstaller.sh
+++ b/CPScripts/mailscanneruninstaller.sh
@@ -23,7 +23,7 @@ elif [ "$OS" = "NAME=\"CloudLinux\"" ]; then
 
 fi
 
-sed -i '/\/^Received:\/ HOLD/d' /etc/postfix/header_checks
+sed -i 's/\/^Received:\/ HOLD/\/^Received:\/ IGNORE/g' /etc/postfix/header_checks
 rm -rf /etc/MailScanner
 rm -rf /usr/share/MailScanner
 rm -rf /usr/local/CyberCP/public/mailwatch


### PR DESCRIPTION
This is when uninstalling Mailscanner. Still need to initially configure for Postfix and when Mailscanner is installed, through Mailscanner.

Ref #667 