### PR TITLE
fix(urls): remove CR (\r) from plugin URL insertion

### DIFF
--- a/pluginInstaller/pluginInstaller.py
+++ b/pluginInstaller/pluginInstaller.py
@@ -57,7 +57,7 @@ class pluginInstaller:
         for items in data:
             if items.find("manageservices") > -1:
                 writeToFile.writelines(items)
-                writeToFile.writelines("    path(\r'" + pluginName + "/', include('" + pluginName + ".urls')),\n")
+                writeToFile.writelines("    path('" + pluginName + "/', include('" + pluginName + ".urls')),\n")
             else:
                 writeToFile.writelines(items)
 


### PR DESCRIPTION
# What

Fixes plugin URL insertion to avoid writing CR (\r) which appears as ^M in urls.py.

# Why

^M causes malformed URL entries and may break Django URL configuration / parsing.

# How

Remove \r from the generated path(...) line.


# Test

Ran plugin install/upgrade once and verified urls.py contains:

path('<plugin>/', include('<plugin>.urls')),

no ^M characters.