### PR TITLE
Refactor: safer removal of plugin URL entries from urls.py

### DIFF
--- a/pluginInstaller/pluginInstaller.py
+++ b/pluginInstaller/pluginInstaller.py
@@ -246,16 +246,17 @@ class pluginInstaller:
 
     @staticmethod
     def removeFromURLs(pluginName):
-        data = open("/usr/local/CyberCP/CyberCP/urls.py", 'r').readlines()
-        writeToFile = open("/usr/local/CyberCP/CyberCP/urls.py", 'w')
+        path = "/usr/local/CyberCP/CyberCP/urls.py"
+        pattern = re.compile(rf"\bpath\([^)]*{re.escape(pluginName)}[^)]*\)")
 
-        for items in data:
-            if items.find(pluginName) > -1:
+        removed = False
+        for line in fileinput.input(path, inplace=True, backup=".bak", encoding="utf-8"):
+            if (not removed) and pattern.search(line):
+                removed = True
                 continue
-            else:
-                writeToFile.writelines(items)
+            print(line, end="")
 
-        writeToFile.close()
+        return removed
 
     @staticmethod
     def informCyberPanelRemoval(pluginName):


### PR DESCRIPTION
### What changed

Refactored removeFromURLs() to remove the plugin URL pattern using a targeted regex and in-place editing, instead of rewriting the entire file and dropping any line containing pluginName.

### Why

The old approach could remove unrelated lines containing the plugin name and sometimes left malformed path( entries after partial edits.

### How

- Uses a compiled regex to find the path(...pluginName...) entry.
- Edits the file in-place and removes only the first matching line.
- Returns True/False depending on whether a removal happened.
- Generates a .bak backup during write.

### Test

Ran removeFromURLs('<plugin>') and verified:

- the corresponding path('<plugin>/', include('<plugin>.urls')), line was removed
- file remains syntactically valid
- function returns True when removed, False when not found