### PR TITLE
docs(manageGIT): fix 'Pleas wait' -> 'Please wait'

### DIFF
--- a/websiteFunctions/templates/websiteFunctions/manageGIT.html
+++ b/websiteFunctions/templates/websiteFunctions/manageGIT.html
@@ -1505,7 +1505,7 @@
                                                     <div class="stick bg-azure"></div>
                                                     <div class="stick bg-azure"></div>
                                                     <div class="stick bg-azure"></div>
-                                                    <h1>Pleas wait...</h1>
+                                                    <h1>Please wait...</h1>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
Fixes #1752. Single-character typo in the git-deploy loading text.

```diff
- <h1>Pleas wait...</h1>
+ <h1>Please wait...</h1>
```

Single template change, no code/logic impact.