### PR TITLE
Fix: remove `redirect` from Sieve require[] in webmail filter rules

### DIFF
--- a/webmail/services/sieve_client.py
+++ b/webmail/services/sieve_client.py
@@ -214,7 +214,8 @@ class SieveClient:
                     folder = 'INBOX.%s' % folder
                 action = 'fileinto "%s";' % folder
             elif action_type == 'forward':
-                requires.add('redirect')
+                # 'redirect' is a built-in Sieve command (RFC 5228), not an extension —
+                # adding it to require[] causes pigeonhole-sieve to reject the script.
                 action = 'redirect "%s";' % action_value
             elif action_type == 'discard':
                 action = 'discard;'


### PR DESCRIPTION
## Summary

- `redirect` is a Sieve **core command** (RFC 5228), not an extension
- Including it in `require[...]` causes pigeonhole-sieve to reject the generated script
- Every forward rule added or edited via the webmail UI hits this bug

## Reproduction

1. Open CyberPanel webmail → Settings → Mail Filter Rules
2. Add a rule with action **Forward to** → save
3. Server-side, `sievec` errors with:
   ```
   require command: `redirect' is not known as a Sieve capability,
   but it is known as a Sieve command that is always available.
   ```
4. The rule is saved to `wm_sieve_rules` but never deployed to Dovecot.

## Fix

Removes the spurious `requires.add('redirect')` call inside the `forward` branch of `SieveClient.rules_to_sieve`. Other real Sieve extensions (`fileinto`, `imap4flags`) remain untouched and are still added to `require[]` correctly.

## Test plan

- [x] Pure forward rule generates a script without `require [...]`
- [x] Mixed forward + move rule generates `require ["fileinto"]` only
- [x] `sievec` compiles the generated script without errors
- [x] A real mail with a matching subject is forwarded correctly via Dovecot LDA