### PR TITLE
Fix SSH key listing/removal for ed25519, ecdsa and FIDO keys

### DIFF
--- a/firewall/firewallManager.py
+++ b/firewall/firewallManager.py
@@ -19,6 +19,7 @@ from django.shortcuts import HttpResponse, render, redirect
 from random import randint
 import time
 from plogical.firewallUtilities import FirewallUtilities
+from plogical.sshKeyUtilities import parse_authorized_key
 from firewall.models import FirewallRules
 from plogical.modSec import modSec
 from plogical.csf import CSF
@@ -403,30 +404,29 @@ class FirewallManager:
                 checker = 0
 
                 for items in data:
-                    if items.find("ssh-rsa") > -1:
-                        keydata = items.split(" ")
+                    parsedKey = parse_authorized_key(items)
+                    if parsedKey is None:
+                        continue
 
+                    key = parsedKey['keyType'] + " " + parsedKey['keyData'][:50]
+                    if parsedKey['comment']:
+                        key = key + "  ..  " + parsedKey['comment']
                         try:
-                            key = "ssh-rsa " + keydata[1][:50] + "  ..  " + keydata[2]
-                            try:
-                                userName = keydata[2][:keydata[2].index("@")]
-                            except:
-                                userName = keydata[2]
-                        except:
-                            key = "ssh-rsa " + keydata[1][:50]
-                            userName = ''
+                            userName = parsedKey['comment'][:parsedKey['comment'].index("@")]
+                        except ValueError:
+                            userName = parsedKey['comment']
+                    else:
+                        userName = ''
 
+                    dic = {'userName': userName,
+                           'key': key,
+                           }
 
-
-                        dic = {'userName': userName,
-                               'key': key,
-                               }
-
-                        if checker == 0:
-                            json_data = json_data + json.dumps(dic)
-                            checker = 1
-                        else:
-                            json_data = json_data + ',' + json.dumps(dic)
+                    if checker == 0:
+                        json_data = json_data + json.dumps(dic)
+                        checker = 1
+                    else:
+                        json_data = json_data + ',' + json.dumps(dic)
 
                 json_data = json_data + ']'
 

--- a/plogical/firewallUtilities.py
+++ b/plogical/firewallUtilities.py
@@ -209,7 +209,7 @@ class FirewallUtilities:
             writeToFile = open(pathToSSH, "w")
 
             for items in data:
-                if items.find("ssh-rsa") > -1 and items.find(keyPart) > -1:
+                if keyPart and items.find(keyPart) > -1:
                     continue
                 else:
                     writeToFile.writelines(items)

--- a/plogical/sshKeyUtilities.py
+++ b/plogical/sshKeyUtilities.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Helpers for parsing OpenSSH ``authorized_keys`` entries.
+
+CyberPanel historically recognised only ``ssh-rsa`` keys when listing or
+deleting authorized keys.  As a result ed25519/ecdsa keys (now the OpenSSH
+default) were invisible in the SSH Access UI and could not be removed.  These
+helpers recognise every key type OpenSSH emits so the UI stays correct
+regardless of the algorithm the user generated their key with.
+"""
+
+# Key types that may appear as the key-type token of an authorized_keys entry.
+# Covers RSA, DSA, ECDSA, Ed25519 and the FIDO/U2F security-key variants.
+SSH_KEY_TYPES = (
+    'ssh-rsa',
+    'ssh-dss',
+    'ssh-ed25519',
+    'ecdsa-sha2-nistp256',
+    'ecdsa-sha2-nistp384',
+    'ecdsa-sha2-nistp521',
+    'sk-ssh-ed25519@openssh.com',
+    'sk-ecdsa-sha2-nistp256@openssh.com',
+)
+
+
+def parse_authorized_key(line):
+    """Parse a single ``authorized_keys`` line.
+
+    Returns a dict ``{'keyType', 'keyData', 'comment'}`` or ``None`` when the
+    line is blank, a comment, or contains no recognised key type.
+
+    The key type is located by scanning the whitespace-separated fields rather
+    than assuming it is the first one, because an entry may be prefixed with
+    options (e.g. ``no-pty,no-X11-forwarding ssh-ed25519 AAAA... user@host``).
+    """
+    if not line or line.lstrip().startswith('#'):
+        return None
+
+    fields = line.split()
+
+    for index, field in enumerate(fields):
+        if field in SSH_KEY_TYPES:
+            keyData = fields[index + 1] if index + 1 < len(fields) else ''
+            if not keyData:
+                return None
+            comment = fields[index + 2] if index + 2 < len(fields) else ''
+            return {'keyType': field, 'keyData': keyData, 'comment': comment}
+
+    return None

--- a/websiteFunctions/website.py
+++ b/websiteFunctions/website.py
@@ -14,6 +14,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "CyberCP.settings")
 django.setup()
 import json
 from plogical.acl import ACLManager
+from plogical.sshKeyUtilities import parse_authorized_key
 import plogical.CyberCPLogFileWriter as logging
 from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter
 from websiteFunctions.models import Websites, ChildDomains, GitLogs, wpplugins, WPSites, WPStaging, WPSitesBackup, \
@@ -7368,28 +7369,29 @@ StrictHostKeyChecking no
             checker = 0
 
             for items in data:
-                if items.find("ssh-rsa") > -1:
-                    keydata = items.split(" ")
+                parsedKey = parse_authorized_key(items)
+                if parsedKey is None:
+                    continue
 
+                key = parsedKey['keyType'] + " " + parsedKey['keyData'][:50]
+                if parsedKey['comment']:
+                    key = key + "  ..  " + parsedKey['comment']
                     try:
-                        key = "ssh-rsa " + keydata[1][:50] + "  ..  " + keydata[2]
-                        try:
-                            userName = keydata[2][:keydata[2].index("@")]
-                        except:
-                            userName = keydata[2]
-                    except:
-                        key = "ssh-rsa " + keydata[1][:50]
-                        userName = ''
+                        userName = parsedKey['comment'][:parsedKey['comment'].index("@")]
+                    except ValueError:
+                        userName = parsedKey['comment']
+                else:
+                    userName = ''
 
-                    dic = {'userName': userName,
-                           'key': key,
-                           }
+                dic = {'userName': userName,
+                       'key': key,
+                       }
 
-                    if checker == 0:
-                        json_data = json_data + json.dumps(dic)
-                        checker = 1
-                    else:
-                        json_data = json_data + ',' + json.dumps(dic)
+                if checker == 0:
+                    json_data = json_data + json.dumps(dic)
+                    checker = 1
+                else:
+                    json_data = json_data + ',' + json.dumps(dic)
 
             json_data = json_data + ']'
 


### PR DESCRIPTION
CyberPanel only recognised "ssh-rsa" entries when listing or deleting authorized_keys, so ed25519/ecdsa keys (the modern OpenSSH default) and FIDO security keys were invisible in the SSH Access UI and could not be removed.

Added plogical/sshKeyUtilities.py to parse every OpenSSH key type (including option-prefixed lines) and wired it into the website and firewall key listings plus the delete matcher.