### PR TITLE
Fix WordPress install failure: MySQL user missing 127.0.0.1 host account

### DIFF
--- a/plogical/mysqlUtilities.py
+++ b/plogical/mysqlUtilities.py
@@ -148,27 +148,36 @@ class mysqlUtilities:
 
             ## create user
 
-            if mysqlUtilities.REMOTEHOST.find('ondigitalocean') > -1:
-                query = "CREATE USER '%s'@'%s' IDENTIFIED WITH mysql_native_password BY '%s'" % (
-                dbuser, HostToUse, dbpassword)
-            else:
-                query = "CREATE USER '" + dbuser + "'@'%s' IDENTIFIED BY '" % (
-                    HostToUse) + dbpassword + "'"
+            def createUserForHost(hostToUse):
+                if mysqlUtilities.REMOTEHOST.find('ondigitalocean') > -1:
+                    query = "CREATE USER '%s'@'%s' IDENTIFIED WITH mysql_native_password BY '%s'" % (
+                    dbuser, hostToUse, dbpassword)
+                else:
+                    query = "CREATE USER '" + dbuser + "'@'%s' IDENTIFIED BY '" % (
+                        hostToUse) + dbpassword + "'"
 
-            if os.path.exists(ProcessUtilities.debugPath):
-                logging.CyberCPLogFileWriter.writeToFile(query)
-
-            cursor.execute(query)
-
-            if mysqlUtilities.RDS == 0:
-                cursor.execute("GRANT ALL PRIVILEGES ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (HostToUse))
                 if os.path.exists(ProcessUtilities.debugPath):
-                    logging.CyberCPLogFileWriter.writeToFile("GRANT ALL PRIVILEGES ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (HostToUse))
-            else:
-                cursor.execute(
-                    "GRANT INDEX, DROP, UPDATE, ALTER, CREATE, SELECT, INSERT, DELETE ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (HostToUse))
-                if os.path.exists(ProcessUtilities.debugPath):
-                    logging.CyberCPLogFileWriter.writeToFile("GRANT INDEX, DROP, UPDATE, ALTER, CREATE, SELECT, INSERT, DELETE ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (HostToUse))
+                    logging.CyberCPLogFileWriter.writeToFile(query)
+
+                cursor.execute(query)
+
+                if mysqlUtilities.RDS == 0:
+                    cursor.execute("GRANT ALL PRIVILEGES ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (hostToUse))
+                    if os.path.exists(ProcessUtilities.debugPath):
+                        logging.CyberCPLogFileWriter.writeToFile("GRANT ALL PRIVILEGES ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (hostToUse))
+                else:
+                    cursor.execute(
+                        "GRANT INDEX, DROP, UPDATE, ALTER, CREATE, SELECT, INSERT, DELETE ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (hostToUse))
+                    if os.path.exists(ProcessUtilities.debugPath):
+                        logging.CyberCPLogFileWriter.writeToFile("GRANT INDEX, DROP, UPDATE, ALTER, CREATE, SELECT, INSERT, DELETE ON " + dbname + ".* TO '" + dbuser + "'@'%s'" % (hostToUse))
+
+            createUserForHost(HostToUse)
+
+            if dbcreate == 1 and HostToUse != '127.0.0.1' and mysqlUtilities.REMOTEHOST in ('', 'localhost', '127.0.0.1'):
+                try:
+                    createUserForHost('127.0.0.1')
+                except BaseException as msg:
+                    logging.CyberCPLogFileWriter.writeToFile(str(msg) + "[createDatabase:127.0.0.1]")
 
             connection.close()
 
@@ -1001,6 +1010,20 @@ password=%s
                 logging.CyberCPLogFileWriter.writeToFile(query)
 
             cursor.execute(query)
+
+            if mysqlUtilities.LOCALHOST != '127.0.0.1':
+                try:
+                    if encrypt == None:
+                        query = "SET PASSWORD FOR '" + userName + "'@'127.0.0.1' = PASSWORD('" + dbPassword + "')"
+                    else:
+                        query = "SET PASSWORD FOR '" + userName + "'@'127.0.0.1' = '" + dbPassword + "'"
+
+                    if os.path.exists(ProcessUtilities.debugPath):
+                        logging.CyberCPLogFileWriter.writeToFile(query)
+
+                    cursor.execute(query)
+                except BaseException as msg:
+                    logging.CyberCPLogFileWriter.writeToFile(str(msg) + "[mysqlUtilities.changePassword:127.0.0.1]")
 
             connection.close()
 

--- a/plogical/mysqlUtilities.py
+++ b/plogical/mysqlUtilities.py
@@ -1011,7 +1011,7 @@ password=%s
 
             cursor.execute(query)
 
-            if mysqlUtilities.LOCALHOST != '127.0.0.1':
+            if LOCALHOST != '127.0.0.1' and mysqlUtilities.REMOTEHOST in ('', 'localhost', '127.0.0.1'):
                 try:
                     if encrypt == None:
                         query = "SET PASSWORD FOR '" + userName + "'@'127.0.0.1' = PASSWORD('" + dbPassword + "')"


### PR DESCRIPTION
## Symptom
WordPress installation in CyberPanel consistently fails with:

Error: Database connection error (1045) Access denied for user
'<dbuser>'@'127.0.0.1' (using password: YES) [404]

## Root cause
`mysqlUtilities.createDatabase()` only ever creates the MySQL user account
on the `localhost` host (via `mysqlUtilities.LOCALHOST`). WordPress installs
via WP-CLI (`wp core install`) connect to the database over TCP to `127.0.0.1`,
which MySQL/MariaDB treats as a distinct host from the `localhost` Unix socket
connection. Without a matching `'<dbuser>'@'127.0.0.1'` account, the connection
is rejected even though the credentials are otherwise correct.

Confirmed via `git log --follow -p` that this has been the behavior since the
function's introduction (commit 02c12d50, Dec 2018) — this is not a regression,
it's a gap that has never been addressed.

## Fix
`createDatabase()` now also creates the account on `127.0.0.1` when the
install is local, with the same privileges as the primary account.
`changePassword()` is updated to keep both accounts in sync on password
changes. Both additions are wrapped in try/except so a failure on the
secondary account never blocks the primary account creation.

## Testing
Reproduced the bug on a live CyberPanel 2.4.x production server (WordPress
install failing 100% of the time with the exact error above). Applied this
patch, retested: WordPress install now completes successfully end to end
(`Successfully Installed`, status `[200]`).

## Scope
Only `plogical/mysqlUtilities.py` is touched. No changes to install flow,
no changes to other application installers (Joomla, Prestashop, etc. — out
of scope for this fix, though they share the same createDatabase() call
and would benefit from the same fix automatically).