### PR TITLE
Fix typo: Eidt → Edit button on Schedule Backup page

### DIFF
--- a/websiteFunctions/templates/websiteFunctions/BackupfileConfig.html
+++ b/websiteFunctions/templates/websiteFunctions/BackupfileConfig.html
@@ -118,7 +118,7 @@
                                 <button ng-click="getupdateid({{ sub.id }})" data-toggle="modal" data-target="#EidtRemoteShedule"
                                         aria-label=""
                                         type="button" class="btn btn-border btn-alt border-yellow btn-link font-yellow">
-                                    Eidt
+                                    Edit
                                 </button>
                                 <a href="{% url 'AddRemoteBackupsite' %}?ID={{ sub.id }}"
                                    aria-label=""


### PR DESCRIPTION
Fixes #1037 - The Edit button on the 'Schedule Backup After adding s3 Server' page says 'Eidt' instead of 'Edit'.