### PR TITLE
fix(firewall): restore banned IP APIs on v3.0.4-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!postgresql-stack/lib/
+!postgresql-stack/lib/**
 lib64/
 parts/
 sdist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to CyberPanel are documented here. The canonical,
 continuously updated changelog also lives at
 https://cyberpanel.net/KnowledgeBase/home/change-logs/
 
+## v3.0.5-dev — 2026-09-01
+
+### Added
+- Optional PostgreSQL stack addon (`postgresql-stack/`): PostgreSQL 17, pg_cron, pgAdmin 4, SSO tile, and LiteSpeed proxy integration.
+- Install flag `--postgresql-stack` and interactive prompt in `cyberpanel.sh`.
+- Upgrade refresh hook `Post_Upgrade_PostgreSQL_Stack` in `cyberpanel_upgrade.sh`.
+- Docs: `to-do/POSTGRESQL-STACK.md`, `install/postgresql_stack.md`.
+
 ## v3.0.5 (build 5) — 2026-08-26
 
 Security update for API authentication and two-factor enforcement.

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -140,6 +140,7 @@ Admin_Pass="1234567"
 
 Memcached="Off"
 Redis="Off"
+PostgreSQL_Stack="Off"
 
 Postfix_Switch="On"
 PowerDNS_Switch="On"
@@ -780,6 +781,7 @@ echo -e "\n\e[31m-v\e[39m or \e[31m--version\e[39m : choose to install CyberPane
 echo -e "Please be aware, this serial number must be obtained from LiteSpeed Store."
 echo -e "And if this serial number has been used before, it must be released/migrated in Store first, otherwise it will fail to start."
 echo -e "\n\e[31m-a\e[39m or \e[31m--addons\e[39m : install addons: memcached, redis, PHP extension for memcached and redis"
+echo -e "\n\e[31m--postgresql-stack\e[39m : optional PostgreSQL 17 + pgAdmin stack (AlmaLinux/RHEL 9+)"
 echo -e "\n\e[31m-p\e[39m or \e[31m--password\e[39m : set password of new installation, empty for default 1234567, [r] or [random] for randomly generated 16 digital password, any other value besides [d] and [r(andom)] will be accept as password, default use 1234567."
 echo -e "e.g. \e[31m-p r\e[39m will generate a random password"
 echo -e "     \e[31m-p 123456789\e[39m will set password to 123456789"
@@ -885,6 +887,10 @@ else
         Memcached="On"
         Redis="On"
         echo -e "\nEnable Addons..."
+      ;;
+      --postgresql-stack)
+        PostgreSQL_Stack="On"
+        echo -e "\nEnable PostgreSQL + pgAdmin stack..."
       ;;
       -h | --help)
         Show_Help
@@ -1140,6 +1146,17 @@ if [[ $Tmp_Input =~ ^(no|n|N) ]]; then
 else
   Redis="On"
   echo -e "\nInstall Redis process and its PHP extension set to Yes...\n"
+fi
+
+echo -e "\nDo you wish to install the optional PostgreSQL + pgAdmin stack?"
+echo -e "(PostgreSQL 17, pg_cron, pgAdmin 4 with CyberPanel SSO tile; AlmaLinux/RHEL 9+ recommended)"
+printf "%s" "Please select [y/N]: "
+read -r Tmp_Input
+if [[ $Tmp_Input =~ ^(yes|y|Y) ]]; then
+  PostgreSQL_Stack="On"
+  echo -e "\nPostgreSQL stack set to Yes...\n"
+else
+  PostgreSQL_Stack="Off"
 fi
 
 echo -e "\nWould you like to set up a WatchDog \e[31m(beta)\e[39m for Web service and Database service ?"
@@ -2097,6 +2114,28 @@ Post_Install_Addon_Redis() {
   fi
 }
 
+Post_Install_Addon_PostgreSQL_Stack() {
+  log_function_start "Post_Install_Addon_PostgreSQL_Stack"
+  local stack_dir="/usr/local/CyberCP/postgresql-stack"
+  if [[ ! -x "${stack_dir}/install.sh" ]]; then
+    echo -e "\nPostgreSQL stack files missing at ${stack_dir}; skipping optional addon.\n"
+    log_function_end "Post_Install_Addon_PostgreSQL_Stack"
+    return 0
+  fi
+  local master_domain pgadmin_domain
+  master_domain="$(hostname -d 2>/dev/null || true)"
+  if [[ -z "${master_domain}" ]]; then
+    master_domain="$(hostname -f 2>/dev/null || echo localhost)"
+  fi
+  pgadmin_domain="pgadmin.${master_domain}"
+  log_info "Installing optional PostgreSQL stack (pgAdmin: ${pgadmin_domain})"
+  if ! bash "${stack_dir}/install.sh" --master-domain "${master_domain}" --domain "${pgadmin_domain}"; then
+    log_error "PostgreSQL stack install failed; see ${stack_dir}/logs/install.log"
+  fi
+  log_function_end "Post_Install_Addon_PostgreSQL_Stack"
+}
+
+
 Post_Install_PHP_Session_Setup() {
 log_function_start "Post_Install_PHP_Session_Setup"
 echo -e "\nSetting up PHP session storage path...\n"
@@ -2736,6 +2775,10 @@ fi
 
 if [[ "$Redis" = "On" ]] ; then
   Post_Install_Addon_Redis
+fi
+
+if [[ "$PostgreSQL_Stack" = "On" ]] ; then
+  Post_Install_Addon_PostgreSQL_Stack
 fi
 
 Post_Install_Required_Components

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -1590,6 +1590,28 @@ systemctl restart lscpd
 
 }
 
+Post_Upgrade_PostgreSQL_Stack() {
+  local stack_dir="/usr/local/CyberCP/postgresql-stack"
+  if [[ ! -d "${stack_dir}" ]]; then
+    return 0
+  fi
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] PostgreSQL stack present at ${stack_dir}" | tee -a /var/log/cyberpanel_upgrade_debug.log
+  if [[ ! -f "${stack_dir}/config.php" ]]; then
+    echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] PostgreSQL stack not configured yet (no config.php); skip refresh" | tee -a /var/log/cyberpanel_upgrade_debug.log
+    return 0
+  fi
+  if [[ -x "${stack_dir}/modules/47-pgadmin-patches.sh" ]]; then
+    bash "${stack_dir}/modules/47-pgadmin-patches.sh" >>/var/log/cyberpanel_upgrade_debug.log 2>&1 || true
+  fi
+  if [[ -x "${stack_dir}/reapply-tile.sh" ]]; then
+    bash "${stack_dir}/reapply-tile.sh" >>/var/log/cyberpanel_upgrade_debug.log 2>&1 || true
+  fi
+  if systemctl list-unit-files pgadmin4.service >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl restart pgadmin4 >>/var/log/cyberpanel_upgrade_debug.log 2>&1 || true
+  fi
+}
+
 Post_Install_Display_Final_Info() {
 
 Panel_Port=$(cat /usr/local/lscp/conf/bind.conf)
@@ -1673,6 +1695,8 @@ Pre_Upgrade_Required_Components
 Main_Upgrade
 
 Post_Upgrade_System_Tweak
+
+Post_Upgrade_PostgreSQL_Stack
 
 Restart_Web_Terminal
 

--- a/firewall/firewallManager.py
+++ b/firewall/firewallManager.py
@@ -4,10 +4,13 @@ import os.path
 import sys
 import django
 
+PROJECT_ROOT = '/usr/local/CyberCP'
+while PROJECT_ROOT in sys.path:
+    sys.path.remove(PROJECT_ROOT)
+sys.path.insert(0, PROJECT_ROOT)
+
 from loginSystem.models import Administrator
 from plogical.httpProc import httpProc
-
-sys.path.append('/usr/local/CyberCP')
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "CyberCP.settings")
 django.setup()
 import json
@@ -21,8 +24,8 @@ from django.shortcuts import HttpResponse, render, redirect
 from random import randint
 import time
 from plogical.firewallUtilities import FirewallUtilities
-from plogical.sshKeyUtilities import authorized_key_records
 from firewall.models import FirewallRules
+from firewall import ruleOrder as FirewallRuleOrder
 from plogical.modSec import modSec
 from plogical.csf import CSF
 from plogical.processUtilities import ProcessUtilities
@@ -33,9 +36,48 @@ class FirewallManager:
     imunifyPath = '/usr/bin/imunify360-agent'
     CLPath = '/etc/sysconfig/cloudlinux'
     imunifyAVPath = '/etc/sysconfig/imunify360/integration.conf'
+    BANNED_IPS_PRIMARY_FILE = '/usr/local/CyberCP/data/banned_ips.json'
+    BANNED_IPS_LEGACY_FILE = '/etc/cyberpanel/banned_ips.json'
 
     def __init__(self, request = None):
         self.request = request
+
+    @staticmethod
+    def _normalize_banned_ip_key(ip):
+        return (ip or '').strip().lower()
+
+    def _remove_autoban_log_by_suffix_id(self, userID, ablog_id_str):
+        final_dic = {'status': 0, 'error_message': 'Auto-ban log entries require the autoBan Security Alerts plugin.'}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+
+    def _load_banned_ips_store(self):
+        """
+        Load banned IPs from the primary store, falling back to legacy path.
+        Returns (data, path_used)
+        """
+        for path in [self.BANNED_IPS_PRIMARY_FILE, self.BANNED_IPS_LEGACY_FILE]:
+            if os.path.exists(path):
+                try:
+                    with open(path, 'r') as f:
+                        return json.load(f), path
+                except Exception as e:
+                    logging.CyberCPLogFileWriter.writeToFile(f'Failed to read banned IPs from {path}: {str(e)}')
+        return [], self.BANNED_IPS_PRIMARY_FILE
+
+    def _save_banned_ips_store(self, data):
+        """
+        Persist banned IPs to the primary store in a writable location.
+        """
+        target = self.BANNED_IPS_PRIMARY_FILE
+        try:
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with open(target, 'w') as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            logging.CyberCPLogFileWriter.writeToFile(f'Failed to write banned IPs to {target}: {str(e)}')
+            raise
+        return target
 
     def securityHome(self, request = None, userID = None):
         proc = httpProc(request, 'firewall/index.html',
@@ -52,7 +94,12 @@ class FirewallManager:
                             None, 'admin')
             return proc.render()
 
-    def getCurrentRules(self, userID = None):
+    def getCurrentRules(self, userID=None, data=None):
+        """
+        Get firewall rules with optional pagination.
+        data may contain: page (1-based), page_size (default 10).
+        Returns: fetchStatus 1, data (JSON array), total_count, page, page_size.
+        """
         try:
             currentACL = ACLManager.loadedACL(userID)
 
@@ -61,34 +108,74 @@ class FirewallManager:
             else:
                 return ACLManager.loadErrorJson('fetchStatus', 0)
 
-            rules = FirewallRules.objects.all()
+            rules_qs = FirewallRuleOrder.ordered_queryset()
+
+            # Ensure CyberPanel port 7080 rule exists in database for visibility
+            cyberpanel_rule_exists = rules_qs.filter(port='7080').exists()
+            if not cyberpanel_rule_exists:
+                try:
+                    FirewallRules(
+                        name="CyberPanel Admin",
+                        proto="tcp",
+                        port="7080",
+                        ipAddress="0.0.0.0/0",
+                        sortOrder=FirewallRuleOrder.next_sort_order()
+                    ).save()
+                    logging.CyberCPLogFileWriter.writeToFile("Added CyberPanel port 7080 to firewall database for UI visibility")
+                except Exception as e:
+                    logging.CyberCPLogFileWriter.writeToFile(f"Failed to add CyberPanel port 7080 to database: {str(e)}")
+                rules_qs = FirewallRuleOrder.ordered_queryset()
+
+            total_count = rules_qs.count()
+            page = 1
+            page_size = 10
+            if data:
+                try:
+                    page = max(1, int(data.get('page', 1)))
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    page_size = max(1, min(100, int(data.get('page_size', 10))))
+                except (TypeError, ValueError):
+                    pass
+
+            start = (page - 1) * page_size
+            end = start + page_size
+            rules = list(rules_qs[start:end])
 
             json_data = "["
-            checker = 0
-
-            for items in rules:
+            for i, items in enumerate(rules):
+                # displayId is 1-based position in the full ordered list (top row = 1)
+                display_id = start + i + 1
                 dic = {
-                       'id': items.id,
-                       'name': items.name,
-                       'proto': items.proto,
-                       'port': items.port,
-                       'ipAddress': items.ipAddress,
-                       }
+                    'id': items.id,
+                    'displayId': display_id,
+                    'sortOrder': items.sortOrder or display_id,
+                    'name': items.name,
+                    'proto': items.proto,
+                    'port': items.port,
+                    'ipAddress': items.ipAddress,
+                }
+                if i > 0:
+                    json_data += ','
+                json_data += json.dumps(dic)
+            json_data += ']'
 
-                if checker == 0:
-                    json_data = json_data + json.dumps(dic)
-                    checker = 1
-                else:
-                    json_data = json_data + ',' + json.dumps(dic)
-
-            json_data = json_data + ']'
-            final_json = json.dumps({'status': 1, 'fetchStatus': 1, 'error_message': "None", "data": json_data})
-            return HttpResponse(final_json)
+            final_json = json.dumps({
+                'status': 1,
+                'fetchStatus': 1,
+                'error_message': "None",
+                "data": json_data,
+                "total_count": total_count,
+                "page": page,
+                "page_size": page_size
+            })
+            return HttpResponse(final_json, content_type='application/json')
 
         except BaseException as msg:
             final_dic = {'status': 0, 'fetchStatus': 0, 'error_message': str(msg)}
             final_json = json.dumps(final_dic)
-            return HttpResponse(final_json)
+            return HttpResponse(final_json, content_type='application/json')
 
     def addRule(self, userID = None, data = None):
         try:
@@ -99,7 +186,6 @@ class FirewallManager:
             else:
                 return ACLManager.loadErrorJson('add_status', 0)
 
-
             ruleName = data['ruleName']
             ruleProtocol = data['ruleProtocol']
             rulePort = data['rulePort']
@@ -107,7 +193,13 @@ class FirewallManager:
 
             FirewallUtilities.addRule(ruleProtocol, rulePort, ruleIP)
 
-            newFWRule = FirewallRules(name=ruleName, proto=ruleProtocol, port=rulePort, ipAddress=ruleIP)
+            newFWRule = FirewallRules(
+                name=ruleName,
+                proto=ruleProtocol,
+                port=rulePort,
+                ipAddress=ruleIP,
+                sortOrder=FirewallRuleOrder.next_sort_order()
+            )
             newFWRule.save()
 
             final_dic = {'status': 1, 'add_status': 1, 'error_message': "None"}
@@ -119,6 +211,75 @@ class FirewallManager:
             final_json = json.dumps(final_dic)
             return HttpResponse(final_json)
 
+    def reorderRules(self, userID=None, data=None):
+        """
+        Persist Firewall Rules table order in MariaDB (sortOrder).
+        Payload options:
+          - direction + id: move one step up/down
+          - page_ordered_ids + page + page_size: reorder within a page
+          - ordered_ids: full global order
+        Works whether firewalld is running or stopped (DB-only).
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] != 1:
+                return ACLManager.loadErrorJson('reorder_status', 0)
+
+            data = data or {}
+            direction = (data.get('direction') or '').strip().lower()
+            rule_id = data.get('id')
+            page_ordered_ids = data.get('page_ordered_ids')
+            ordered_ids = data.get('ordered_ids')
+
+            if direction in ('up', 'down') and rule_id is not None:
+                new_order = FirewallRuleOrder.move_rule(rule_id, direction)
+            elif page_ordered_ids is not None:
+                page = data.get('page', 1)
+                page_size = data.get('page_size', 10)
+                new_order = FirewallRuleOrder.apply_page_order(
+                    page_ordered_ids, page, page_size
+                )
+            elif ordered_ids is not None:
+                new_order = FirewallRuleOrder.apply_ordered_ids(ordered_ids)
+            else:
+                final_dic = {
+                    'status': 0,
+                    'reorder_status': 0,
+                    'error_message': 'Provide direction+id, page_ordered_ids, or ordered_ids'
+                }
+                return HttpResponse(
+                    json.dumps(final_dic), content_type='application/json'
+                )
+
+            final_dic = {
+                'status': 1,
+                'reorder_status': 1,
+                'error_message': 'None',
+                'ordered_ids': new_order,
+            }
+            return HttpResponse(
+                json.dumps(final_dic), content_type='application/json'
+            )
+
+        except ValueError as msg:
+            final_dic = {
+                'status': 0,
+                'reorder_status': 0,
+                'error_message': str(msg)
+            }
+            return HttpResponse(
+                json.dumps(final_dic), content_type='application/json'
+            )
+        except BaseException as msg:
+            final_dic = {
+                'status': 0,
+                'reorder_status': 0,
+                'error_message': str(msg)
+            }
+            return HttpResponse(
+                json.dumps(final_dic), content_type='application/json'
+            )
+
     def deleteRule(self, userID = None, data = None):
         try:
 
@@ -129,7 +290,6 @@ class FirewallManager:
             else:
                 return ACLManager.loadErrorJson('delete_status', 0)
 
-
             ruleID = data['id']
             ruleProtocol = data['proto']
             rulePort = data['port']
@@ -139,6 +299,7 @@ class FirewallManager:
 
             delRule = FirewallRules.objects.get(id=ruleID)
             delRule.delete()
+            FirewallRuleOrder.renumber_all()
 
             final_dic = {'status': 1, 'delete_status': 1, 'error_message': "None"}
             final_json = json.dumps(final_dic)
@@ -148,6 +309,59 @@ class FirewallManager:
             final_dic = {'status': 0, 'delete_status': 0, 'error_message': str(msg)}
             final_json = json.dumps(final_dic)
             return HttpResponse(final_json)
+
+    def modifyRule(self, userID=None, data=None):
+        """
+        Update an existing firewall rule: remove old rule from firewalld and DB, add new rule.
+        data: id, name, proto, port, ruleIP (or ipAddress).
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] != 1:
+                return ACLManager.loadErrorJson('status', 0)
+
+            rule_id = data.get('id')
+            new_name = (data.get('name') or data.get('ruleName') or '').strip()
+            new_proto = (data.get('proto') or data.get('ruleProtocol') or 'tcp').strip().lower()
+            new_port = (data.get('port') or data.get('rulePort') or '').strip()
+            new_ip = (data.get('ruleIP') or data.get('ipAddress') or '0.0.0.0/0').strip()
+
+            if not rule_id:
+                final_dic = {'status': 0, 'error_message': 'Rule ID is required'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+            if not new_name:
+                final_dic = {'status': 0, 'error_message': 'Rule name is required'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+            if new_proto not in ('tcp', 'udp'):
+                final_dic = {'status': 0, 'error_message': 'Protocol must be tcp or udp'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+            if not new_port:
+                final_dic = {'status': 0, 'error_message': 'Port is required'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            existing = FirewallRules.objects.get(id=rule_id)
+            old_proto = existing.proto
+            old_port = existing.port
+            old_ip = existing.ipAddress
+
+            FirewallUtilities.deleteRule(old_proto, old_port, old_ip)
+            FirewallUtilities.addRule(new_proto, new_port, new_ip)
+
+            existing.name = new_name
+            existing.proto = new_proto
+            existing.port = new_port
+            existing.ipAddress = new_ip
+            existing.save()
+
+            final_dic = {'status': 1, 'modify_status': 1, 'error_message': 'None'}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+        except FirewallRules.DoesNotExist:
+            final_dic = {'status': 0, 'error_message': 'Rule not found'}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json')
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json')
 
     def reloadFirewall(self, userID = None, data = None):
         try:
@@ -191,6 +405,14 @@ class FirewallManager:
             res = ProcessUtilities.executioner(command)
 
             if res == 1:
+                # UI order lives in MariaDB sortOrder; getCurrentRules / start both read that order.
+                # firewalld rich-rules are a set of accepts (port opens); order is persisted for the panel.
+                try:
+                    FirewallRuleOrder.ensure_sort_orders()
+                except BaseException as order_msg:
+                    logging.CyberCPLogFileWriter.writeToFile(
+                        "Firewall start: ensure sortOrder warning: %s" % str(order_msg)
+                    )
                 final_dic = {'start_status': 1, 'error_message': "None"}
                 final_json = json.dumps(final_dic)
                 return HttpResponse(final_json)
@@ -307,7 +529,36 @@ class FirewallManager:
                 cat = "sudo cat " + pathToKeyFile
                 data = ProcessUtilities.outputExecutioner(cat).split('\n')
 
-                json_data = json.dumps(authorized_key_records(data))
+                json_data = "["
+                checker = 0
+
+                for items in data:
+                    if items.find("ssh-rsa") > -1:
+                        keydata = items.split(" ")
+
+                        try:
+                            key = "ssh-rsa " + keydata[1][:50] + "  ..  " + keydata[2]
+                            try:
+                                userName = keydata[2][:keydata[2].index("@")]
+                            except:
+                                userName = keydata[2]
+                        except:
+                            key = "ssh-rsa " + keydata[1][:50]
+                            userName = ''
+
+
+
+                        dic = {'userName': userName,
+                               'key': key,
+                               }
+
+                        if checker == 0:
+                            json_data = json_data + json.dumps(dic)
+                            checker = 1
+                        else:
+                            json_data = json_data + ',' + json.dumps(dic)
+
+                json_data = json_data + ']'
 
                 final_json = json.dumps({'status': 1, 'error_message': "None", "data": json_data})
                 return HttpResponse(final_json)
@@ -330,16 +581,13 @@ class FirewallManager:
             sshPort = data['sshPort']
             rootLogin = data['rootLogin']
 
-            if not is_safe_port(sshPort):
-                return ACLManager.loadErrorJson('saveStatus', 0)
-
             if rootLogin == True:
                 rootLogin = "1"
             else:
                 rootLogin = "0"
 
             execPath = "/usr/local/CyberCP/bin/python " + virtualHostUtilities.cyberPanel + "/plogical/firewallUtilities.py"
-            execPath = execPath + " saveSSHConfigs --type " + shlex.quote(str(type)) + " --sshPort " + str(sshPort) + " --rootLogin " + rootLogin
+            execPath = execPath + " saveSSHConfigs --type " + str(type) + " --sshPort " + sshPort + " --rootLogin " + rootLogin
 
             output = ProcessUtilities.outputExecutioner(execPath)
 
@@ -394,7 +642,7 @@ class FirewallManager:
             key = data['key']
 
             execPath = "/usr/local/CyberCP/bin/python " + virtualHostUtilities.cyberPanel + "/plogical/firewallUtilities.py"
-            execPath = execPath + " deleteSSHKey --key " + shlex.quote(key)
+            execPath = execPath + " deleteSSHKey --key '" + key + "'"
 
             output = ProcessUtilities.outputExecutioner(execPath)
 
@@ -403,11 +651,7 @@ class FirewallManager:
                 final_json = json.dumps(final_dic)
                 return HttpResponse(final_json)
             else:
-                final_dic = {
-                    'status': 0,
-                    'delete_status': 0,
-                    'error_message': output,
-                }
+                final_dic = {'status': 1, 'delete_status': 1, "error_mssage": output}
                 final_json = json.dumps(final_dic)
                 return HttpResponse(final_json)
 
@@ -865,8 +1109,7 @@ class FirewallManager:
                 modSecInstalled = 0
 
                 for items in httpdConfig:
-                    if (not items.strip().startswith('#') and
-                            items.strip().startswith('module mod_security')):
+                    if items.find('module mod_security') > -1:
                         modSecInstalled = 1
                         break
 
@@ -989,26 +1232,72 @@ class FirewallManager:
                 owaspInstalled = 0
 
                 if modSecInstalled:
-                    activeConfig = [
-                        items.strip() for items in httpdConfig
-                        if items.strip() and not items.strip().startswith('#')
-                    ]
-                    comodoInstalled = int(any(
-                        items.startswith('modsecurity_rules_file ') and
-                        'modsec/comodo' in items
-                        for items in activeConfig
-                    ))
-                    if modSec.hasActiveOWASPDirective(httpdConfig):
-                        command = 'sudo cat ' + modSec.OWASP_MASTER_CONF
-                        rulesConfig = ProcessUtilities.outputExecutioner(
-                            command
-                        ).splitlines()
-                        owaspInstalled = int(any(
-                            items.strip().lower().startswith('include ')
-                            for items in rulesConfig
-                            if items.strip() and
-                            not items.strip().startswith('#')
-                        ))
+                    command = "sudo cat " + confPath
+                    httpdConfig = ProcessUtilities.outputExecutioner(command).splitlines()
+
+                    for items in httpdConfig:
+                        # Check for Comodo rules
+                        if items.find('modsec/comodo') > -1:
+                            comodoInstalled = 1
+                        # Check for OWASP rules - improved detection
+                        elif items.find('modsec/owasp') > -1 or items.find('owasp-modsecurity-crs') > -1:
+                            owaspInstalled = 1
+
+                        if owaspInstalled == 1 and comodoInstalled == 1:
+                            break
+
+                    # Check rules.conf and other OWASP CRS locations
+                    if owaspInstalled == 0:
+                        rulesConfPath = os.path.join(virtualHostUtilities.Server_root, "conf/modsec/rules.conf")
+                        if os.path.exists(rulesConfPath):
+                            try:
+                                command = "sudo cat " + rulesConfPath
+                                rulesConfig = ProcessUtilities.outputExecutioner(command).splitlines()
+                                for items in rulesConfig:
+                                    # Check for OWASP includes in rules.conf (case-insensitive)
+                                    if ('owasp' in items.lower() or 'crs-setup' in items.lower()) and \
+                                       ('include' in items.lower() or 'modsecurity_rules_file' in items.lower()):
+                                        owaspInstalled = 1
+                                        break
+                            except:
+                                pass
+
+                    if owaspInstalled == 0:
+                        owaspPath = os.path.join(virtualHostUtilities.Server_root, "conf/modsec/owasp-modsecurity-crs-4.18.0")
+                        if os.path.exists(owaspPath) and os.path.exists(os.path.join(owaspPath, "owasp-master.conf")):
+                            owaspInstalled = 1
+
+                    if owaspInstalled == 0:
+                        owaspMasterConf = os.path.join(virtualHostUtilities.Server_root, "conf/modsec/owasp-modsecurity-crs-3.0-master/owasp-master.conf")
+                        if os.path.exists(owaspMasterConf):
+                            try:
+                                command = "sudo cat " + owaspMasterConf
+                                owaspConfig = ProcessUtilities.outputExecutioner(command).splitlines()
+                                for items in owaspConfig:
+                                    if items.strip() and not items.strip().startswith('#') and 'include' in items.lower():
+                                        owaspInstalled = 1
+                                        break
+                            except Exception:
+                                pass
+
+                    if owaspInstalled == 0:
+                        owaspRulesDir = os.path.join(virtualHostUtilities.Server_root, "conf/modsec/owasp-modsecurity-crs-3.0-master/rules")
+                        if os.path.exists(owaspRulesDir):
+                            try:
+                                command = "sudo ls " + owaspRulesDir + " | grep -c '.conf'"
+                                output = ProcessUtilities.outputExecutioner(command).strip()
+                                if output.isdigit() and int(output) > 0:
+                                    for items in httpdConfig:
+                                        if 'owasp-modsecurity-crs' in items.lower() or 'owasp-master.conf' in items.lower():
+                                            owaspInstalled = 1
+                                            break
+                            except Exception:
+                                pass
+
+                    if comodoInstalled == 0:
+                        comodoPath = os.path.join(virtualHostUtilities.Server_root, "conf/modsec/comodo")
+                        if os.path.exists(comodoPath) and os.path.exists(os.path.join(comodoPath, "modsecurity.conf")):
+                            comodoInstalled = 1
 
                     final_dic = {
                         'modSecInstalled': 1,
@@ -1496,7 +1785,7 @@ class FirewallManager:
             ProcessUtilities.executioner(command)
 
             execPath = "sudo /usr/local/CyberCP/bin/python " + virtualHostUtilities.cyberPanel + "/plogical/csf.py"
-            execPath = execPath + " modifyPorts --protocol " + shlex.quote(protocol) + " --ports " + portsPath
+            execPath = execPath + " modifyPorts --protocol " + protocol + " --ports " + portsPath
             output = ProcessUtilities.outputExecutioner(execPath)
 
             if output.find("1,None") > -1:
@@ -1556,6 +1845,18 @@ class FirewallManager:
 
         data['CL'] = 1
 
+        # Auto-fix PHP-FPM issues when accessing Imunify360 page
+        try:
+            from plogical import upgrade
+            logging.CyberCPLogFileWriter.writeToFile("Auto-fixing PHP-FPM pool configurations for Imunify360 compatibility...")
+            fix_result = upgrade.Upgrade.CreateMissingPoolsforFPM()
+            if fix_result == 0:
+                logging.CyberCPLogFileWriter.writeToFile("PHP-FPM pool configurations auto-fixed successfully")
+            else:
+                logging.CyberCPLogFileWriter.writeToFile("Warning: PHP-FPM auto-fix had issues")
+        except Exception as e:
+            logging.CyberCPLogFileWriter.writeToFile(f"Error in auto-fix for Imunify360: {str(e)}")
+
         if os.path.exists(FirewallManager.imunifyPath):
             data['imunify'] = 1
         else:
@@ -1585,24 +1886,12 @@ class FirewallManager:
                 logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
                                                           'Not authorized to install container packages. [404].',
                                                           1)
-                return HttpResponse(json.dumps({
-                    'status': 0,
-                    'error_message': 'Not authorized to install Imunify360.',
-                }))
+                return 0
 
             data = json.loads(self.request.body)
-            key = str(data.get('key', '')).strip()
-            if not key:
-                data_ret = {'status': 0, 'error_message': 'An Imunify360 license key is required.'}
-                return HttpResponse(json.dumps(data_ret))
 
-            from plogical.imunify_integration import (
-                build_install_worker_command,
-                ensure_install_status_file,
-            )
-            ensure_install_status_file(reset=True)
-
-            execPath = build_install_worker_command('360', key=key)
+            execPath = "/usr/local/CyberCP/bin/python /usr/local/CyberCP/CLManager/CageFS.py"
+            execPath = execPath + " --function submitinstallImunify --key %s" % (data['key'])
             ProcessUtilities.popenExecutioner(execPath)
 
             data_ret = {'status': 1, 'error_message': 'None'}
@@ -1611,10 +1900,6 @@ class FirewallManager:
 
         except BaseException as msg:
             logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath, str(msg) + ' [404].', 1)
-            return HttpResponse(json.dumps({
-                'status': 0,
-                'error_message': 'Could not start the Imunify360 installation. Check the installation log.',
-            }))
 
     def imunifyAV(self):
         ipFile = "/etc/cyberpanel/machineIP"
@@ -1627,8 +1912,34 @@ class FirewallManager:
         data = {}
         data['ipAddress'] = fullAddress
 
+        # Auto-fix PHP-FPM issues when accessing ImunifyAV page
+        try:
+            from plogical import upgrade
+            logging.CyberCPLogFileWriter.writeToFile("Auto-fixing PHP-FPM pool configurations for ImunifyAV compatibility...")
+            fix_result = upgrade.Upgrade.CreateMissingPoolsforFPM()
+            if fix_result == 0:
+                logging.CyberCPLogFileWriter.writeToFile("PHP-FPM pool configurations auto-fixed successfully")
+            else:
+                logging.CyberCPLogFileWriter.writeToFile("Warning: PHP-FPM auto-fix had issues")
+        except Exception as e:
+            logging.CyberCPLogFileWriter.writeToFile(f"Error in auto-fix for ImunifyAV: {str(e)}")
+
         if os.path.exists(FirewallManager.imunifyAVPath):
             data['imunify'] = 1
+            try:
+                from plogical.imunify_integration import (
+                    integration_conf_needs_repair,
+                    repair_integration_conf,
+                    ensure_clscripts_executable,
+                    chmod_imunify_execute_files,
+                    IMUNIFY_AV_UI,
+                )
+                ensure_clscripts_executable()
+                if integration_conf_needs_repair():
+                    repair_integration_conf()
+                chmod_imunify_execute_files(IMUNIFY_AV_UI)
+            except BaseException:
+                pass
         else:
             data['imunify'] = 0
 
@@ -1652,18 +1963,10 @@ class FirewallManager:
                 logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath,
                                                           'Not authorized to install container packages. [404].',
                                                           1)
-                return HttpResponse(json.dumps({
-                    'status': 0,
-                    'error_message': 'Not authorized to install ImunifyAV.',
-                }))
+                return 0
 
-            from plogical.imunify_integration import (
-                build_install_worker_command,
-                ensure_install_status_file,
-            )
-            ensure_install_status_file(reset=True)
-
-            execPath = build_install_worker_command('av')
+            execPath = "/usr/local/CyberCP/bin/python /usr/local/CyberCP/CLManager/CageFS.py"
+            execPath = execPath + " --function submitinstallImunifyAV"
             ProcessUtilities.popenExecutioner(execPath)
 
             data_ret = {'status': 1, 'error_message': 'None'}
@@ -1672,10 +1975,6 @@ class FirewallManager:
 
         except BaseException as msg:
             logging.CyberCPLogFileWriter.statusWriter(ServerStatusUtil.lswsInstallStatusPath, str(msg) + ' [404].', 1)
-            return HttpResponse(json.dumps({
-                'status': 0,
-                'error_message': 'Could not start the ImunifyAV installation. Check the installation log.',
-            }))
 
 
 
@@ -1765,3 +2064,1048 @@ class FirewallManager:
             final_dic = {'status': 0, 'error_message': str(msg)}
             final_json = json.dumps(final_dic)
             return HttpResponse(final_json)
+
+    def getBannedIPs(self, userID=None, data=None):
+        """
+        Get list of banned IP addresses with optional pagination.
+        data may contain: page (1-based), page_size (default 10).
+        Returns: status 1, bannedIPs (array), total_count, page, page_size.
+        """
+        try:
+            admin = Administrator.objects.get(pk=userID)
+            if admin.acl.adminStatus != 1:
+                return ACLManager.loadErrorJson('status', 0)
+
+            active_banned_ips = []
+            db_ips = set()  # IPs already added from DB (for merge with JSON)
+            current_time = int(time.time())
+            from django.db.utils import OperationalError, ProgrammingError
+
+            for _migrate_attempt in (1, 2):
+                try:
+                    from firewall.models import BannedIP
+                    from django.db.models import Q
+
+                    banned_ips_queryset = BannedIP.objects.filter(
+                        active=True
+                    ).filter(
+                        Q(expires__isnull=True) | Q(expires__gt=current_time)
+                    ).order_by('-banned_on')
+
+                    for banned_ip in banned_ips_queryset:
+                        try:
+                            ip_data = {
+                                'id': banned_ip.id,
+                                'ip': banned_ip.ip_address,
+                                'reason': banned_ip.reason,
+                                'duration': banned_ip.duration,
+                                'banned_on': banned_ip.get_banned_on_display(),
+                                'expires': banned_ip.get_expires_display(),
+                                'active': not banned_ip.is_expired() and banned_ip.active
+                            }
+                            if ip_data['active']:
+                                active_banned_ips.append(ip_data)
+                                db_ips.add(banned_ip.ip_address)
+                        except Exception as row_e:
+                            import plogical.CyberCPLogFileWriter as _log
+                            _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: skip row %s: %s' % (getattr(banned_ip, 'ip_address', '?'), str(row_e)))
+                    break
+                except (OperationalError, ProgrammingError) as e:
+                    import plogical.CyberCPLogFileWriter as _log
+                    _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: DB error (table may be missing). Error: %s' % str(e))
+                    if _migrate_attempt == 1:
+                        try:
+                            from django.core.management import call_command
+                            call_command('migrate', 'firewall', verbosity=0)
+                            _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: ran migrate firewall, retrying.')
+                        except Exception as migrate_err:
+                            _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: migrate firewall failed: %s' % str(migrate_err))
+                    else:
+                        _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: DB read failed after retry, merging with JSON.')
+                    if _migrate_attempt == 2:
+                        break
+                except Exception as e:
+                    import plogical.CyberCPLogFileWriter as _log
+                    _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: DB read failed, merging with JSON (%s)' % str(e))
+                    break
+
+            # If ORM returned nothing but we have the table, try raw SQL as fallback
+            if not active_banned_ips:
+                try:
+                    from django.db import connection
+                    with connection.cursor() as cursor:
+                        cursor.execute(
+                            """SELECT id, ip_address, reason, duration, banned_on, expires
+                               FROM firewall_bannedips WHERE active = 1
+                               AND (expires IS NULL OR expires > %s)
+                               ORDER BY banned_on DESC""",
+                            [current_time]
+                        )
+                        for row in cursor.fetchall():
+                            bid, ip_addr, reason_val, duration_val, banned_on_val, expires_val = row
+                            if ip_addr in db_ips:
+                                continue
+                            from datetime import datetime
+                            if banned_on_val:
+                                banned_on_str = banned_on_val.strftime('%Y-%m-%d %H:%M:%S') if hasattr(banned_on_val, 'strftime') else str(banned_on_val)
+                            else:
+                                banned_on_str = 'N/A'
+                            if expires_val is None:
+                                expires_str = 'Never'
+                            else:
+                                try:
+                                    expires_str = datetime.fromtimestamp(expires_val).strftime('%Y-%m-%d %H:%M:%S')
+                                except Exception:
+                                    expires_str = 'Never'
+                            active_banned_ips.append({
+                                'id': bid,
+                                'ip': ip_addr or '',
+                                'reason': reason_val or '',
+                                'duration': duration_val or 'permanent',
+                                'banned_on': banned_on_str,
+                                'expires': expires_str,
+                                'active': True
+                            })
+                            db_ips.add(ip_addr)
+                except Exception as raw_e:
+                    import plogical.CyberCPLogFileWriter as _log
+                    _log.CyberCPLogFileWriter.writeToFile('getBannedIPs: raw fallback failed: %s' % str(raw_e))
+
+            # Always load JSON store and merge: show bans from both DB and JSON (e.g. bans from base/SSH logs)
+            banned_ips, _ = self._load_banned_ips_store()
+            for b in banned_ips:
+                if not b.get('active', True):
+                    continue
+                ip_val = (b.get('ip') or '').strip()
+                if ip_val in db_ips:
+                    continue
+                exp = b.get('expires')
+                if exp == 'Never' or exp is None:
+                    expires_display = 'Never'
+                elif isinstance(exp, (int, float)):
+                    from datetime import datetime
+                    try:
+                        expires_display = datetime.fromtimestamp(exp).strftime('%Y-%m-%d %H:%M:%S')
+                    except Exception:
+                        expires_display = 'Never'
+                else:
+                    expires_display = str(exp)
+                banned_on = b.get('banned_on')
+                if isinstance(banned_on, (int, float)):
+                    from datetime import datetime
+                    try:
+                        banned_on = datetime.fromtimestamp(banned_on).strftime('%Y-%m-%d %H:%M:%S')
+                    except Exception:
+                        banned_on = 'N/A'
+                else:
+                    banned_on = str(banned_on) if banned_on else 'N/A'
+                active_banned_ips.append({
+                    'id': b.get('id'),
+                    'ip': ip_val,
+                    'reason': b.get('reason', ''),
+                    'duration': b.get('duration', 'permanent'),
+                    'banned_on': banned_on,
+                    'expires': expires_display,
+                    'active': True
+                })
+
+            # Auto Ban Security Alerts: show log-only / plugin-visible bans on same list as firewall UI
+            self._merge_autoban_security_alerts_logs(active_banned_ips, current_time)
+
+            # Optional server-side search: filter by IP or reason (case-insensitive substring)
+            # Normalize: strip query and compare against stripped IP/reason so "1.2.3.4" matches stored "  1.2.3.4  "
+            search_q = (data.get('search') or data.get('q') or '').strip() if data else ''
+            if search_q:
+                search_lower = search_q.lower()
+                def matches(b):
+                    ip = (b.get('ip') or '').strip().lower()
+                    reason = (b.get('reason') or '').strip().lower()
+                    return search_lower in ip or search_lower in reason
+                active_banned_ips = [b for b in active_banned_ips if matches(b)]
+
+            total_count = len(active_banned_ips)
+            page = 1
+            page_size = 10
+            if data:
+                try:
+                    page = max(1, int(data.get('page', 1)))
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    page_size = max(1, min(100, int(data.get('page_size', 10))))
+                except (TypeError, ValueError):
+                    pass
+
+            start = (page - 1) * page_size
+            end = start + page_size
+            paged_list = active_banned_ips[start:end]
+
+            final_dic = {
+                'status': 1,
+                'bannedIPs': paged_list,
+                'total_count': total_count,
+                'page': page,
+                'page_size': page_size
+            }
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+        except BaseException as msg:
+            import plogical.CyberCPLogFileWriter as logging
+            logging.CyberCPLogFileWriter.writeToFile('Error in getBannedIPs: %s' % str(msg))
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+    def addBannedIP(self, userID=None, data=None):
+        """
+        Add a banned IP address. Uses database (BannedIP model) as primary storage;
+        JSON file is used only when the model is unavailable (fallback). Export/Import use JSON format.
+        """
+        try:
+            admin = Administrator.objects.get(pk=userID)
+            if admin.acl.adminStatus != 1:
+                final_dic = {'status': 0, 'error_message': 'You are not authorized to access this resource.', 'error': 'You are not authorized to access this resource.'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json', status=403)
+
+            ip = data.get('ip', '').strip()
+            reason = data.get('reason', '').strip()
+            duration = (data.get('duration') or '24h').strip().lower()
+
+            if not ip or not reason:
+                final_dic = {'status': 0, 'error_message': 'IP address and reason are required', 'error': 'IP address and reason are required'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            # Validate IP address format
+            import ipaddress
+            try:
+                ipaddress.ip_address(ip.split('/')[0])  # Handle CIDR notation
+            except ValueError:
+                final_dic = {'status': 0, 'error_message': 'Invalid IP address format', 'error': 'Invalid IP address format'}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            try:
+                from plogical.sshSecurityWhitelistUtilities import SSHSecurityWhitelistUtilities
+                if SSHSecurityWhitelistUtilities.is_whitelisted(ip):
+                    final_dic = {
+                        'status': 0,
+                        'error_message': 'This IP is on the SSH Security trusted list and cannot be banned. Remove it from Trusted IPs first.',
+                        'error': 'SSH Security whitelist',
+                    }
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+            except Exception:
+                pass
+
+            current_time = time.time()
+            duration_map = {
+                '1h': 3600,
+                '24h': 86400,
+                '7d': 604800,
+                '30d': 2592000
+            }
+            if duration == 'permanent':
+                expires_ts = None  # Never expires
+            else:
+                duration_seconds = duration_map.get(duration, 86400)
+                expires_ts = int(current_time) + duration_seconds
+
+            # Prefer database (BannedIP model) for primary storage
+            try:
+                from firewall.models import BannedIP
+            except Exception as e:
+                BannedIP = None
+                logging.CyberCPLogFileWriter.writeToFile('addBannedIP: BannedIP model unavailable, using JSON fallback: %s' % str(e))
+
+            if BannedIP is not None:
+                # Primary path: save to database
+                existing = BannedIP.objects.filter(ip_address=ip, active=True).first()
+                if existing:
+                    # IP already banned: close any active connections from this IP so they cannot keep trying
+                    try:
+                        FirewallUtilities.closeConnectionsFromIP(ip)
+                    except Exception as close_err:
+                        logging.CyberCPLogFileWriter.writeToFile('addBannedIP: closeConnectionsFromIP %s: %s' % (ip, str(close_err)))
+                    msg = 'IP address %s was already banned; any active connections from this IP have been terminated.' % ip
+                    final_dic = {'status': 1, 'message': msg}
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+                try:
+                    new_ban = BannedIP(
+                        ip_address=ip,
+                        reason=reason,
+                        duration=duration,
+                        expires=expires_ts,
+                        active=True
+                    )
+                    new_ban.save()
+                except Exception as e:
+                    logging.CyberCPLogFileWriter.writeToFile('addBannedIP: failed to save to DB: %s' % str(e))
+                    final_dic = {'status': 0, 'error_message': 'Failed to save banned IP to database: %s' % str(e), 'error': str(e)}
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+            else:
+                # Fallback: JSON store (only when DB unavailable)
+                banned_ips, _ = self._load_banned_ips_store()
+                for banned_ip in banned_ips:
+                    if banned_ip.get('ip') == ip and banned_ip.get('active', True):
+                        # IP already banned: close any active connections from this IP so they cannot keep trying
+                        try:
+                            FirewallUtilities.closeConnectionsFromIP(ip)
+                        except Exception as close_err:
+                            logging.CyberCPLogFileWriter.writeToFile('addBannedIP: closeConnectionsFromIP %s: %s' % (ip, str(close_err)))
+                        msg = 'IP address %s was already banned; any active connections from this IP have been terminated.' % ip
+                        final_dic = {'status': 1, 'message': msg}
+                        return HttpResponse(json.dumps(final_dic), content_type='application/json')
+                new_banned_ip = {
+                    'id': int(current_time),
+                    'ip': ip,
+                    'reason': reason,
+                    'duration': duration,
+                    'banned_on': current_time,
+                    'expires': 'Never' if expires_ts is None else expires_ts,
+                    'active': True
+                }
+                banned_ips.append(new_banned_ip)
+                try:
+                    self._save_banned_ips_store(banned_ips)
+                except Exception as e:
+                    logging.CyberCPLogFileWriter.writeToFile('addBannedIP: failed to save JSON store: %s' % str(e))
+                    final_dic = {'status': 0, 'error_message': 'Failed to save banned IP: %s' % str(e), 'error': str(e)}
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            # Apply firewall rule (same for DB and JSON path)
+            try:
+                block_ok, block_msg = FirewallUtilities.blockIP(ip, reason)
+                if not block_ok:
+                    if BannedIP is not None:
+                        try:
+                            BannedIP.objects.filter(ip_address=ip, active=True).delete()
+                        except Exception:
+                            pass
+                    else:
+                        banned_ips_rollback = [b for b in banned_ips if b.get('ip') != ip or not b.get('active', True)]
+                        if len(banned_ips_rollback) < len(banned_ips):
+                            self._save_banned_ips_store(banned_ips_rollback)
+                    logging.CyberCPLogFileWriter.writeToFile('Failed to add firewalld rule for %s: %s' % (ip, block_msg))
+                    err_msg = block_msg or 'Failed to add firewall rule'
+                    final_dic = {'status': 0, 'error_message': err_msg, 'error': err_msg}
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+                logging.CyberCPLogFileWriter.writeToFile('Banned IP %s with reason: %s' % (ip, reason))
+            except Exception as e:
+                if BannedIP is not None:
+                    try:
+                        BannedIP.objects.filter(ip_address=ip, active=True).delete()
+                    except Exception:
+                        pass
+                else:
+                    try:
+                        banned_ips_rollback = [b for b in banned_ips if b.get('ip') != ip or not b.get('active', True)]
+                        if len(banned_ips_rollback) < len(banned_ips):
+                            self._save_banned_ips_store(banned_ips_rollback)
+                    except Exception:
+                        pass
+                logging.CyberCPLogFileWriter.writeToFile('Failed to add firewalld rule for %s: %s' % (ip, str(e)))
+                err_msg = 'Firewall command failed: %s' % str(e)
+                final_dic = {'status': 0, 'error_message': err_msg, 'error': err_msg}
+                return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            final_dic = {'status': 1, 'message': 'IP address %s has been banned successfully' % ip}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+        except BaseException as msg:
+            err_msg = str(msg)
+            final_dic = {'status': 0, 'error_message': err_msg, 'error': err_msg}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+    def removeBannedIP(self, userID=None, data=None):
+        """
+        Remove/unban an IP address.
+        Supports both BannedIP database model and JSON file storage.
+        """
+        try:
+            admin = Administrator.objects.get(pk=userID)
+            if admin.acl.adminStatus != 1:
+                return ACLManager.loadError()
+
+            banned_ip_id = data.get('id')
+            if isinstance(banned_ip_id, str) and banned_ip_id.startswith('ablog-'):
+                final_dic = {'status': 0, 'error_message': 'Use the autoBan Security Alerts plugin.'}; return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            requested_ip = (data.get('ip') or '').strip()
+            ip_to_unban = None
+
+            try:
+                if isinstance(banned_ip_id, str) and banned_ip_id.isdigit():
+                    banned_ip_id = int(banned_ip_id)
+                elif isinstance(banned_ip_id, float):
+                    banned_ip_id = int(banned_ip_id)
+            except Exception:
+                pass
+
+            # Try database (BannedIP model) first - ids are typically small integers
+            try:
+                from firewall.models import BannedIP
+            except Exception as e:
+                BannedIP = None
+                logging.CyberCPLogFileWriter.writeToFile(f'Warning: BannedIP model import failed, using JSON fallback: {str(e)}')
+
+            if BannedIP is not None:
+                try:
+                    banned_ip = None
+                    if banned_ip_id not in (None, ''):
+                        try:
+                            banned_ip = BannedIP.objects.get(pk=banned_ip_id)
+                        except BannedIP.DoesNotExist:
+                            banned_ip = None
+                    if banned_ip is None and requested_ip:
+                        banned_ip = BannedIP.objects.filter(ip_address=requested_ip).first()
+                    if banned_ip is None:
+                        raise BannedIP.DoesNotExist()
+                    ip_to_unban = banned_ip.ip_address
+                    banned_ip.active = False
+                    banned_ip.save()
+                    # Remove firewalld rule using FirewallUtilities (runs with proper privileges)
+                    try:
+                        FirewallUtilities.unblockIP(ip_to_unban)
+                    except Exception as e:
+                        logging.CyberCPLogFileWriter.writeToFile(f'Warning removing firewalld rule: {str(e)}')
+                    final_dic = {'status': 1, 'message': f'IP address {ip_to_unban} has been unbanned successfully'}
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+                except BannedIP.DoesNotExist:
+                    pass
+
+            # Fall back to JSON file storage
+            banned_ips, _ = self._load_banned_ips_store()
+
+            # Find and update the banned IP
+            ip_to_unban = None
+            for banned_ip in banned_ips:
+                id_match = banned_ip_id not in (None, '') and str(banned_ip.get('id')) == str(banned_ip_id)
+                ip_match = requested_ip and str(banned_ip.get('ip', '')).strip() == requested_ip
+                if id_match or ip_match:
+                    banned_ip['active'] = False
+                    banned_ip['unbanned_on'] = time.time()
+                    ip_to_unban = banned_ip['ip']
+                    break
+
+            if not ip_to_unban:
+                final_dic = {'status': 0, 'error_message': 'Banned IP not found'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json, content_type='application/json')
+
+            # Save updated banned IPs
+            self._save_banned_ips_store(banned_ips)
+
+            # Remove firewalld rule using FirewallUtilities (runs with proper privileges)
+            try:
+                FirewallUtilities.unblockIP(ip_to_unban)
+                logging.CyberCPLogFileWriter.writeToFile(f'Unbanned IP {ip_to_unban}')
+            except Exception as e:
+                logging.CyberCPLogFileWriter.writeToFile(f'Warning removing firewalld rule for {ip_to_unban}: {str(e)}')
+
+            final_dic = {'status': 1, 'message': f'IP address {ip_to_unban} has been unbanned successfully'}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+    def deleteBannedIP(self, userID=None, data=None):
+        """
+        Permanently delete a banned IP record.
+        Supports both BannedIP database model and JSON file storage.
+        """
+        try:
+            admin = Administrator.objects.get(pk=userID)
+            if admin.acl.adminStatus != 1:
+                return ACLManager.loadError()
+
+            banned_ip_id = data.get('id')
+            if isinstance(banned_ip_id, str) and banned_ip_id.startswith('ablog-'):
+                final_dic = {'status': 0, 'error_message': 'Use the autoBan Security Alerts plugin.'}; return HttpResponse(json.dumps(final_dic), content_type='application/json')
+
+            requested_ip = (data.get('ip') or '').strip()
+
+            try:
+                if isinstance(banned_ip_id, str) and banned_ip_id.isdigit():
+                    banned_ip_id = int(banned_ip_id)
+                elif isinstance(banned_ip_id, float):
+                    banned_ip_id = int(banned_ip_id)
+            except Exception:
+                pass
+
+            # Try database (BannedIP model) first
+            try:
+                from firewall.models import BannedIP
+            except Exception as e:
+                BannedIP = None
+                logging.CyberCPLogFileWriter.writeToFile(f'Warning: BannedIP model import failed, using JSON fallback: {str(e)}')
+
+            if BannedIP is not None:
+                try:
+                    banned_ip = None
+                    if banned_ip_id not in (None, ''):
+                        try:
+                            banned_ip = BannedIP.objects.get(pk=banned_ip_id)
+                        except BannedIP.DoesNotExist:
+                            banned_ip = None
+                    if banned_ip is None and requested_ip:
+                        banned_ip = BannedIP.objects.filter(ip_address=requested_ip).first()
+                    if banned_ip is None:
+                        raise BannedIP.DoesNotExist()
+                    ip_to_delete = banned_ip.ip_address
+                    banned_ip.delete()
+                    logging.CyberCPLogFileWriter.writeToFile(f'Deleted banned IP record for {ip_to_delete}')
+                    final_dic = {'status': 1, 'message': f'Banned IP record for {ip_to_delete} has been deleted successfully'}
+                    return HttpResponse(json.dumps(final_dic), content_type='application/json')
+                except BannedIP.DoesNotExist:
+                    pass
+
+            # Fall back to JSON file storage
+            banned_ips, _ = self._load_banned_ips_store()
+
+            # Find and remove the banned IP
+            ip_to_delete = None
+            updated_banned_ips = []
+            for banned_ip in banned_ips:
+                id_match = banned_ip_id not in (None, '') and str(banned_ip.get('id')) == str(banned_ip_id)
+                ip_match = requested_ip and str(banned_ip.get('ip', '')).strip() == requested_ip
+                if id_match or ip_match:
+                    ip_to_delete = banned_ip['ip']
+                else:
+                    updated_banned_ips.append(banned_ip)
+
+            if not ip_to_delete:
+                final_dic = {'status': 0, 'error_message': 'Banned IP record not found'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json, content_type='application/json')
+
+            # Save updated banned IPs
+            self._save_banned_ips_store(updated_banned_ips)
+
+            logging.CyberCPLogFileWriter.writeToFile(f'Deleted banned IP record for {ip_to_delete}')
+
+            final_dic = {'status': 1, 'message': f'Banned IP record for {ip_to_delete} has been deleted successfully'}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+        except BaseException as msg:
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+    def modifyBannedIP(self, userID=None, data=None):
+        """
+        Modify an existing banned IP record (reason, duration).
+        Supports both BannedIP database model and JSON file storage.
+        """
+        try:
+            admin = Administrator.objects.get(pk=userID)
+            if admin.acl.adminStatus != 1:
+                return ACLManager.loadError()
+
+            banned_ip_id = data.get('id')
+            requested_ip = (data.get('ip') or '').strip()
+            reason = data.get('reason', '').strip()
+            duration = data.get('duration', '').strip()
+
+            try:
+                if isinstance(banned_ip_id, str) and banned_ip_id.isdigit():
+                    banned_ip_id = int(banned_ip_id)
+                elif isinstance(banned_ip_id, float):
+                    banned_ip_id = int(banned_ip_id)
+            except Exception:
+                pass
+
+            if banned_ip_id in (None, '') and not requested_ip:
+                final_dic = {'status': 0, 'error_message': 'Banned IP ID or IP address is required'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json, content_type='application/json')
+
+            if not reason:
+                final_dic = {'status': 0, 'error_message': 'Reason is required'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json, content_type='application/json')
+
+            # Try database (BannedIP model) first - ids are typically small integers
+            try:
+                from firewall.models import BannedIP
+            except Exception as e:
+                BannedIP = None
+                logging.CyberCPLogFileWriter.writeToFile(f'Warning: BannedIP model import failed, using JSON fallback: {str(e)}')
+
+            if BannedIP is not None:
+                try:
+                    banned_ip = None
+                    if banned_ip_id not in (None, ''):
+                        try:
+                            banned_ip = BannedIP.objects.get(pk=banned_ip_id)
+                        except BannedIP.DoesNotExist:
+                            banned_ip = None
+                    if banned_ip is None and requested_ip:
+                        banned_ip = BannedIP.objects.filter(ip_address=requested_ip).first()
+                    if banned_ip is None:
+                        raise BannedIP.DoesNotExist()
+                    if not banned_ip.active:
+                        final_dic = {'status': 0, 'error_message': 'Cannot modify an inactive/expired ban'}
+                        final_json = json.dumps(final_dic)
+                        return HttpResponse(final_json, content_type='application/json')
+
+                    banned_ip.reason = reason
+                    if duration:
+                        banned_ip.duration = duration
+                        duration_map = {
+                            '1h': 3600,
+                            '24h': 86400,
+                            '7d': 604800,
+                            '30d': 2592000,
+                            'permanent': None
+                        }
+                        if duration == 'permanent':
+                            banned_ip.expires = None
+                        else:
+                            duration_seconds = duration_map.get(duration, 86400)
+                            banned_ip.expires = int(time.time()) + duration_seconds
+                    banned_ip.save()
+
+                    logging.CyberCPLogFileWriter.writeToFile(f'Modified banned IP {banned_ip.ip_address} (id={banned_ip_id})')
+                    final_dic = {'status': 1, 'message': f'Banned IP {banned_ip.ip_address} has been updated successfully'}
+                    final_json = json.dumps(final_dic)
+                    return HttpResponse(final_json, content_type='application/json')
+
+                except BannedIP.DoesNotExist:
+                    pass
+
+            # Fall back to JSON file storage (ids are timestamps)
+            banned_ips, _ = self._load_banned_ips_store()
+
+            updated = False
+            for banned_ip in banned_ips:
+                id_match = banned_ip_id not in (None, '') and str(banned_ip.get('id')) == str(banned_ip_id)
+                ip_match = requested_ip and str(banned_ip.get('ip', '')).strip() == requested_ip
+                if (id_match or ip_match) and banned_ip.get('active', True):
+                    banned_ip['reason'] = reason
+                    if duration:
+                        banned_ip['duration'] = duration
+                        if duration == 'permanent':
+                            banned_ip['expires'] = 'Never'
+                        else:
+                            duration_map = {
+                                '1h': 3600,
+                                '24h': 86400,
+                                '7d': 604800,
+                                '30d': 2592000
+                            }
+                            duration_seconds = duration_map.get(duration, 86400)
+                            banned_ip['expires'] = time.time() + duration_seconds
+                    updated = True
+                    break
+
+            if not updated:
+                final_dic = {'status': 0, 'error_message': 'Banned IP record not found'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json, content_type='application/json')
+
+            self._save_banned_ips_store(banned_ips)
+
+            ip_addr = next((b.get('ip') for b in banned_ips if (str(b.get('id')) == str(banned_ip_id)) or (requested_ip and str(b.get('ip', '')).strip() == requested_ip)), 'unknown')
+            logging.CyberCPLogFileWriter.writeToFile(f'Modified banned IP {ip_addr} (id={banned_ip_id}) in JSON')
+            final_dic = {'status': 1, 'message': f'Banned IP {ip_addr} has been updated successfully'}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+        except BaseException as msg:
+            logging.CyberCPLogFileWriter.writeToFile(f'Error in modifyBannedIP: {str(msg)}')
+            final_dic = {'status': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json, content_type='application/json')
+
+    def exportFirewallRules(self, userID=None):
+        """
+        Export all custom firewall rules. Format from POST body: { "format": "json" | "excel" }.
+        JSON: application/json file. Excel: text/csv (opens in Excel).
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            else:
+                return ACLManager.loadErrorJson('exportStatus', 0)
+
+            # Optional format from request body
+            export_format = 'json'
+            if getattr(self, 'request', None) and self.request.method == 'POST' and self.request.body:
+                try:
+                    body = self.request.body
+                    if isinstance(body, bytes):
+                        body = body.decode('utf-8')
+                    data = json.loads(body) if body.strip() else {}
+                    export_format = (data.get('format') or 'json').strip().lower()
+                    if export_format not in ('json', 'excel'):
+                        export_format = 'json'
+                except Exception:
+                    pass
+
+            # Get all firewall rules (stable UI order)
+            rules = FirewallRuleOrder.ordered_queryset()
+            default_rules = ['CyberPanel Admin', 'SSHCustom']
+            custom_rules = []
+            for rule in rules:
+                if rule.name not in default_rules:
+                    custom_rules.append({
+                        'name': rule.name,
+                        'proto': rule.proto,
+                        'port': rule.port,
+                        'ipAddress': rule.ipAddress,
+                        'sortOrder': rule.sortOrder
+                    })
+
+            logging.CyberCPLogFileWriter.writeToFile(f"Firewall rules exported successfully. Total rules: {len(custom_rules)}")
+
+            if export_format == 'excel':
+                import csv
+                import io
+                buf = io.StringIO()
+                writer = csv.writer(buf)
+                writer.writerow(['name', 'proto', 'port', 'ipAddress'])
+                for r in custom_rules:
+                    writer.writerow([r.get('name', ''), r.get('proto', ''), r.get('port', ''), r.get('ipAddress', '')])
+                content = buf.getvalue()
+                response = HttpResponse(content, content_type='text/csv; charset=utf-8')
+                response['Content-Disposition'] = f'attachment; filename="firewall_rules_export_{int(time.time())}.csv"'
+                return response
+
+            export_data = {
+                'version': '1.0',
+                'exported_at': time.strftime('%Y-%m-%d %H:%M:%S'),
+                'total_rules': len(custom_rules),
+                'rules': custom_rules
+            }
+            json_content = json.dumps(export_data, indent=2)
+            response = HttpResponse(json_content, content_type='application/json')
+            response['Content-Disposition'] = f'attachment; filename="firewall_rules_export_{int(time.time())}.json"'
+            return response
+
+        except BaseException as msg:
+            final_dic = {'exportStatus': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def importFirewallRules(self, userID=None, data=None):
+        """
+        Import firewall rules from a JSON file
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+
+            if currentACL['admin'] == 1:
+                pass
+            else:
+                return ACLManager.loadErrorJson('importStatus', 0)
+
+            # Handle file upload
+            if hasattr(self.request, 'FILES') and 'import_file' in self.request.FILES:
+                import_file = self.request.FILES['import_file']
+                raw = import_file.read().decode('utf-8')
+                name = (import_file.name or '').lower()
+                if name.endswith('.csv'):
+                    import csv
+                    import io
+                    reader = csv.DictReader(io.StringIO(raw))
+                    rules_list = []
+                    for row in reader:
+                        rules_list.append({
+                            'name': str(row.get('name', '')).strip(),
+                            'proto': str(row.get('proto', 'tcp')).strip().lower() or 'tcp',
+                            'port': str(row.get('port', '')).strip(),
+                            'ipAddress': str(row.get('ipAddress', '0.0.0.0/0')).strip() or '0.0.0.0/0'
+                        })
+                    import_data = {'rules': rules_list}
+                else:
+                    import_data = json.loads(raw)
+            else:
+                # Fallback to file path method
+                import_file_path = data.get('import_file_path', '')
+                
+                if not import_file_path or not os.path.exists(import_file_path):
+                    final_dic = {'importStatus': 0, 'error_message': 'Import file not found or invalid path'}
+                    final_json = json.dumps(final_dic)
+                    return HttpResponse(final_json)
+                
+                # Read and parse the import file
+                with open(import_file_path, 'r') as f:
+                    import_data = json.load(f)
+            
+            # Validate the import data structure
+            if 'rules' not in import_data:
+                final_dic = {'importStatus': 0, 'error_message': 'Invalid import file format. Missing rules array.'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json)
+            
+            imported_count = 0
+            skipped_count = 0
+            error_count = 0
+            errors = []
+            
+            # Default CyberPanel rules to exclude from import
+            default_rules = ['CyberPanel Admin', 'SSHCustom']
+            
+            for rule_data in import_data['rules']:
+                try:
+                    # Skip default rules
+                    if rule_data.get('name', '') in default_rules:
+                        skipped_count += 1
+                        continue
+                    
+                    # Check if rule already exists
+                    existing_rule = FirewallRules.objects.filter(
+                        name=rule_data['name'],
+                        proto=rule_data['proto'],
+                        port=rule_data['port'],
+                        ipAddress=rule_data['ipAddress']
+                    ).first()
+                    
+                    if existing_rule:
+                        skipped_count += 1
+                        continue
+                    
+                    # Add the rule to the system firewall
+                    FirewallUtilities.addRule(
+                        rule_data['proto'], 
+                        rule_data['port'], 
+                        rule_data['ipAddress']
+                    )
+                    
+                    # Add the rule to the database
+                    new_rule = FirewallRules(
+                        name=rule_data['name'],
+                        proto=rule_data['proto'],
+                        port=rule_data['port'],
+                        ipAddress=rule_data['ipAddress'],
+                        sortOrder=FirewallRuleOrder.next_sort_order()
+                    )
+                    new_rule.save()
+                    
+                    imported_count += 1
+                    
+                except Exception as e:
+                    error_count += 1
+                    errors.append(f"Rule '{rule_data.get('name', 'Unknown')}': {str(e)}")
+                    logging.CyberCPLogFileWriter.writeToFile(f"Error importing rule {rule_data.get('name', 'Unknown')}: {str(e)}")
+            
+            logging.CyberCPLogFileWriter.writeToFile(f"Firewall rules import completed. Imported: {imported_count}, Skipped: {skipped_count}, Errors: {error_count}")
+            
+            final_dic = {
+                'importStatus': 1,
+                'error_message': "None",
+                'imported_count': imported_count,
+                'skipped_count': skipped_count,
+                'error_count': error_count,
+                'errors': errors
+            }
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+        except BaseException as msg:
+            final_dic = {'importStatus': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def exportBannedIPs(self, userID=None):
+        """
+        Export banned IPs to a JSON file
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] != 1:
+                return ACLManager.loadErrorJson('exportStatus', 0)
+
+            banned_records = []
+
+            # Try database model first
+            try:
+                from firewall.models import BannedIP
+            except Exception as e:
+                BannedIP = None
+                logging.CyberCPLogFileWriter.writeToFile(f'Warning: BannedIP model import failed, using JSON fallback: {str(e)}')
+
+            if BannedIP is not None:
+                try:
+                    for banned_ip in BannedIP.objects.all().order_by('-banned_on'):
+                        banned_records.append({
+                            'id': int(banned_ip.id),
+                            'ip': str(banned_ip.ip_address or ''),
+                            'reason': str(banned_ip.reason or ''),
+                            'duration': str(banned_ip.duration or 'permanent'),
+                            'banned_on': str(banned_ip.get_banned_on_display() or 'N/A'),
+                            'expires': str(banned_ip.get_expires_display() or 'Never'),
+                            'active': bool(banned_ip.active and not banned_ip.is_expired())
+                        })
+                except Exception as e:
+                    logging.CyberCPLogFileWriter.writeToFile(f'Error exporting banned IPs from DB: {str(e)}')
+
+            # If DB is unavailable/empty, fall back to JSON file
+            if not banned_records:
+                banned_ips, _ = self._load_banned_ips_store()
+
+                for b in banned_ips:
+                    banned_records.append({
+                        'id': b.get('id'),
+                        'ip': str(b.get('ip') or ''),
+                        'reason': str(b.get('reason') or ''),
+                        'duration': str(b.get('duration') or 'permanent'),
+                        'banned_on': str(b.get('banned_on') if b.get('banned_on') is not None else 'N/A'),
+                        'expires': str(b.get('expires') if b.get('expires') is not None else 'Never'),
+                        'active': bool(b.get('active', True))
+                    })
+
+            export_data = {
+                'version': '1.0',
+                'exported_at': time.strftime('%Y-%m-%d %H:%M:%S'),
+                'total_banned_ips': len(banned_records),
+                'banned_ips': banned_records
+            }
+
+            json_content = json.dumps(export_data, indent=2)
+            logging.CyberCPLogFileWriter.writeToFile(f"Banned IPs exported successfully. Total: {len(banned_records)}")
+
+            response = HttpResponse(json_content, content_type='application/json')
+            response['Content-Disposition'] = f'attachment; filename=\"banned_ips_export_{int(time.time())}.json\"'
+            return response
+
+        except BaseException as msg:
+            final_dic = {'exportStatus': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+    def importBannedIPs(self, userID=None, data=None):
+        """
+        Import banned IPs from a JSON file
+        """
+        try:
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] != 1:
+                return ACLManager.loadErrorJson('importStatus', 0)
+
+            request_files = getattr(self.request, 'FILES', None)
+            if request_files and 'import_file' in request_files:
+                import_file = self.request.FILES['import_file']
+                import_data = json.loads(import_file.read().decode('utf-8'))
+            else:
+                import_file_path = data.get('import_file_path', '') if data else ''
+                if not import_file_path or not os.path.exists(import_file_path):
+                    final_dic = {'importStatus': 0, 'error_message': 'Import file not found or invalid path'}
+                    final_json = json.dumps(final_dic)
+                    return HttpResponse(final_json)
+                with open(import_file_path, 'r') as f:
+                    import_data = json.load(f)
+
+            if 'banned_ips' not in import_data or not isinstance(import_data.get('banned_ips'), list):
+                final_dic = {'importStatus': 0, 'error_message': 'Invalid import file format. Missing banned_ips array.'}
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json)
+
+            imported_count = 0
+            skipped_count = 0
+            error_count = 0
+            errors = []
+
+            # Try database model first
+            try:
+                from firewall.models import BannedIP
+            except Exception as e:
+                BannedIP = None
+                logging.CyberCPLogFileWriter.writeToFile(f'Warning: BannedIP model import failed, using JSON fallback: {str(e)}')
+
+            # Prepare JSON fallback store if needed
+            banned_ips_json = []
+            if BannedIP is None:
+                banned_ips_json, _ = self._load_banned_ips_store()
+
+            import ipaddress
+            for item in import_data.get('banned_ips', []):
+                try:
+                    ip = (item.get('ip') or '').strip()
+                    reason = (item.get('reason') or '').strip()
+                    duration = (item.get('duration') or 'permanent').strip()
+                    active = bool(item.get('active', True))
+
+                    if not ip or not reason:
+                        skipped_count += 1
+                        continue
+
+                    try:
+                        ipaddress.ip_address(ip.split('/')[0])
+                    except ValueError:
+                        error_count += 1
+                        errors.append(f"Invalid IP: {ip}")
+                        continue
+
+                    if BannedIP is not None:
+                        existing = BannedIP.objects.filter(ip_address=ip).first()
+                        if existing:
+                            skipped_count += 1
+                            continue
+                        new_ban = BannedIP(
+                            ip_address=ip,
+                            reason=reason,
+                            duration=duration,
+                            active=active
+                        )
+                        if duration == 'permanent':
+                            new_ban.expires = None
+                        else:
+                            duration_map = {'1h': 3600, '24h': 86400, '7d': 604800, '30d': 2592000}
+                            duration_seconds = duration_map.get(duration, 86400)
+                            new_ban.expires = int(time.time()) + duration_seconds
+                        new_ban.save()
+                        imported_count += 1
+                    else:
+                        # JSON fallback storage
+                        exists = any(str(b.get('ip', '')).strip() == ip for b in banned_ips_json)
+                        if exists:
+                            skipped_count += 1
+                            continue
+                        banned_ips_json.append({
+                            'id': int(time.time() * 1000),
+                            'ip': ip,
+                            'reason': reason,
+                            'duration': duration,
+                            'banned_on': int(time.time()),
+                            'expires': 'Never' if duration == 'permanent' else int(time.time()) + {
+                                '1h': 3600, '24h': 86400, '7d': 604800, '30d': 2592000
+                            }.get(duration, 86400),
+                            'active': active
+                        })
+                        imported_count += 1
+
+                except Exception as e:
+                    error_count += 1
+                    errors.append(f"IP '{item.get('ip', 'unknown')}': {str(e)}")
+                    logging.CyberCPLogFileWriter.writeToFile(f"Error importing banned IP {item.get('ip', 'unknown')}: {str(e)}")
+
+            if BannedIP is None:
+                self._save_banned_ips_store(banned_ips_json)
+
+            logging.CyberCPLogFileWriter.writeToFile(f"Banned IPs import completed. Imported: {imported_count}, Skipped: {skipped_count}, Errors: {error_count}")
+
+            final_dic = {
+                'importStatus': 1,
+                'error_message': "None",
+                'imported_count': imported_count,
+                'skipped_count': skipped_count,
+                'error_count': error_count,
+                'errors': errors
+            }
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+        except BaseException as msg:
+            final_dic = {'importStatus': 0, 'error_message': str(msg)}
+            final_json = json.dumps(final_dic)
+            return HttpResponse(final_json)
+
+
+
+

--- a/firewall/migrations/0001_initial.py
+++ b/firewall/migrations/0001_initial.py
@@ -1,0 +1,40 @@
+# Generated migration for firewall app - BannedIP model
+# Primary storage for banned IPs is the database; JSON is used only for export/import.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BannedIP',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('ip_address', models.GenericIPAddressField(db_index=True, unique=True, verbose_name='IP Address')),
+                ('reason', models.CharField(max_length=255, verbose_name='Ban Reason')),
+                ('duration', models.CharField(default='permanent', max_length=50, verbose_name='Duration')),
+                ('banned_on', models.DateTimeField(auto_now_add=True, verbose_name='Banned On')),
+                ('expires', models.BigIntegerField(blank=True, null=True, verbose_name='Expires Timestamp')),
+                ('active', models.BooleanField(db_index=True, default=True, verbose_name='Active')),
+            ],
+            options={
+                'verbose_name': 'Banned IP',
+                'verbose_name_plural': 'Banned IPs',
+                'db_table': 'firewall_bannedips',
+            },
+        ),
+        migrations.AddIndex(
+            model_name='bannedip',
+            index=models.Index(fields=['ip_address', 'active'], name='fw_bannedip_ip_active_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='bannedip',
+            index=models.Index(fields=['active', 'expires'], name='fw_bannedip_active_exp_idx'),
+        ),
+    ]

--- a/firewall/migrations/0002_create_bannedips_table.py
+++ b/firewall/migrations/0002_create_bannedips_table.py
@@ -1,0 +1,34 @@
+# Create firewall_bannedips if an older install applied firewall.0001_initial before
+# the BannedIP model existed. Some upgrades then have the migration recorded but the
+# table missing, causing MySQL error 1146 when banning an IP from the dashboard.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('firewall', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+CREATE TABLE IF NOT EXISTS `firewall_bannedips` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `ip_address` varchar(39) NOT NULL,
+  `reason` varchar(255) NOT NULL,
+  `duration` varchar(50) NOT NULL DEFAULT 'permanent',
+  `banned_on` datetime(6) NOT NULL,
+  `expires` bigint(20) DEFAULT NULL,
+  `active` bool NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `firewall_bannedips_ip_address_uniq` (`ip_address`),
+  KEY `fw_bannedip_ip_active_idx` (`ip_address`,`active`),
+  KEY `fw_bannedip_active_exp_idx` (`active`,`expires`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+""",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]
+

--- a/firewall/migrations/0003_firewallrules_sortorder.py
+++ b/firewall/migrations/0003_firewallrules_sortorder.py
@@ -1,0 +1,80 @@
+# Add sortOrder on legacy firewall_firewallrules (table predates Django migrations).
+
+from django.db import migrations, connection
+
+
+def add_sort_order_column(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'firewall_firewallrules'
+              AND COLUMN_NAME = 'sortOrder'
+            """
+        )
+        exists = cursor.fetchone()[0] > 0
+        if not exists:
+            cursor.execute(
+                "ALTER TABLE `firewall_firewallrules` "
+                "ADD COLUMN `sortOrder` int(11) NOT NULL DEFAULT 0"
+            )
+        cursor.execute(
+            "UPDATE `firewall_firewallrules` SET `sortOrder` = `id` "
+            "WHERE `sortOrder` IS NULL OR `sortOrder` <= 0"
+        )
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'firewall_firewallrules'
+              AND INDEX_NAME = 'firewall_fw_rules_sortorder_idx'
+            """
+        )
+        idx_exists = cursor.fetchone()[0] > 0
+        if not idx_exists:
+            cursor.execute(
+                "CREATE INDEX `firewall_fw_rules_sortorder_idx` "
+                "ON `firewall_firewallrules` (`sortOrder`)"
+            )
+
+
+def drop_sort_order_column(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'firewall_firewallrules'
+              AND COLUMN_NAME = 'sortOrder'
+            """
+        )
+        exists = cursor.fetchone()[0] > 0
+        if exists:
+            cursor.execute(
+                """
+                SELECT COUNT(*) FROM information_schema.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = 'firewall_firewallrules'
+                  AND INDEX_NAME = 'firewall_fw_rules_sortorder_idx'
+                """
+            )
+            if cursor.fetchone()[0] > 0:
+                cursor.execute(
+                    "DROP INDEX `firewall_fw_rules_sortorder_idx` "
+                    "ON `firewall_firewallrules`"
+                )
+            cursor.execute(
+                "ALTER TABLE `firewall_firewallrules` DROP COLUMN `sortOrder`"
+            )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('firewall', '0002_create_bannedips_table'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_sort_order_column, drop_sort_order_column),
+    ]

--- a/firewall/models.py
+++ b/firewall/models.py
@@ -1,4 +1,8 @@
 from django.db import models
+from django.utils import timezone
+from django.utils.timezone import now
+import time
+
 
 # Create your models here.
 
@@ -7,3 +11,59 @@ class FirewallRules(models.Model):
     proto = models.CharField(max_length=10)
     port = models.CharField(max_length=25)
     ipAddress = models.CharField(max_length=30,default="0.0.0.0/0")
+    # Display / apply order for Firewall Rules table (1 = top). Independent of auto-increment PK.
+    sortOrder = models.IntegerField(default=0, db_index=True)
+
+
+class BannedIP(models.Model):
+    """
+    Model to store banned IP addresses
+    """
+    ip_address = models.GenericIPAddressField(unique=True, db_index=True, verbose_name="IP Address")
+    reason = models.CharField(max_length=255, verbose_name="Ban Reason")
+    duration = models.CharField(max_length=50, default='permanent', verbose_name="Duration")
+    banned_on = models.DateTimeField(auto_now_add=True, verbose_name="Banned On")
+    expires = models.BigIntegerField(null=True, blank=True, verbose_name="Expires Timestamp")
+    # expires can be: null (never expires), or Unix timestamp
+    active = models.BooleanField(default=True, db_index=True, verbose_name="Active")
+    
+    class Meta:
+        db_table = 'firewall_bannedips'
+        verbose_name = "Banned IP"
+        verbose_name_plural = "Banned IPs"
+        indexes = [
+            models.Index(fields=['ip_address', 'active']),
+            models.Index(fields=['active', 'expires']),
+        ]
+    
+    def __str__(self):
+        return f"{self.ip_address} - {self.reason}"
+    
+    def is_expired(self):
+        """
+        Check if the ban has expired
+        Returns True if expired, False if still active
+        """
+        if self.expires is None:
+            # Never expires
+            return False
+        current_time = int(time.time())
+        return self.expires <= current_time
+    
+    def get_expires_display(self):
+        """
+        Get human-readable expiration date
+        """
+        if self.expires is None:
+            return "Never"
+        return timezone.datetime.fromtimestamp(self.expires).strftime('%Y-%m-%d %H:%M:%S')
+    
+    def get_banned_on_display(self):
+        """
+        Get human-readable banned on date
+        """
+        if self.banned_on:
+            if hasattr(self.banned_on, 'strftime'):
+                return self.banned_on.strftime('%Y-%m-%d %H:%M:%S')
+            return str(self.banned_on)
+        return timezone.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/firewall/ruleOrder.py
+++ b/firewall/ruleOrder.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""Firewall rule display order helpers (MariaDB sortOrder)."""
+from __future__ import unicode_literals
+
+from django.db import transaction
+from django.db.models import Max
+
+from firewall.models import FirewallRules
+
+
+def ensure_sort_orders():
+    """Backfill sortOrder for rows that still use the default 0."""
+    rules = list(FirewallRules.objects.all().order_by('id'))
+    needs = [r for r in rules if not r.sortOrder or r.sortOrder <= 0]
+    if not needs and rules:
+        # Also normalize gaps if every row already has a positive order
+        return
+    if not rules:
+        return
+    with transaction.atomic():
+        for idx, rule in enumerate(rules, start=1):
+            if rule.sortOrder != idx:
+                rule.sortOrder = idx
+                rule.save(update_fields=['sortOrder'])
+
+
+def next_sort_order():
+    """Return the next sortOrder value for a newly added rule."""
+    ensure_sort_orders()
+    current = FirewallRules.objects.aggregate(m=Max('sortOrder')).get('m') or 0
+    return int(current) + 1
+
+
+def ordered_queryset():
+    """Rules queryset ordered for UI and apply paths."""
+    ensure_sort_orders()
+    return FirewallRules.objects.all().order_by('sortOrder', 'id')
+
+
+def renumber_all():
+    """Force contiguous sortOrder values 1..n in current order."""
+    rules = list(FirewallRules.objects.all().order_by('sortOrder', 'id'))
+    with transaction.atomic():
+        for idx, rule in enumerate(rules, start=1):
+            if rule.sortOrder != idx:
+                rule.sortOrder = idx
+                rule.save(update_fields=['sortOrder'])
+    return [r.id for r in rules]
+
+
+def apply_ordered_ids(ordered_ids):
+    """
+    Persist a full global order from a list of primary keys.
+    Returns the new ordered id list (1..n).
+    """
+    if not isinstance(ordered_ids, (list, tuple)) or not ordered_ids:
+        raise ValueError('ordered_ids must be a non-empty list of rule IDs')
+
+    try:
+        ordered_ids = [int(x) for x in ordered_ids]
+    except (TypeError, ValueError):
+        raise ValueError('ordered_ids must contain integers')
+
+    existing = list(FirewallRules.objects.values_list('id', flat=True))
+    if sorted(ordered_ids) != sorted(existing):
+        raise ValueError('ordered_ids must include every firewall rule exactly once')
+
+    with transaction.atomic():
+        for idx, rule_id in enumerate(ordered_ids, start=1):
+            FirewallRules.objects.filter(id=rule_id).update(sortOrder=idx)
+    return ordered_ids
+
+
+def apply_page_order(page_ordered_ids, page, page_size):
+    """
+    Replace the slice for the given page with page_ordered_ids and renumber.
+    """
+    if not isinstance(page_ordered_ids, (list, tuple)) or not page_ordered_ids:
+        raise ValueError('page_ordered_ids must be a non-empty list')
+
+    try:
+        page = max(1, int(page))
+        page_size = max(1, min(100, int(page_size)))
+        page_ordered_ids = [int(x) for x in page_ordered_ids]
+    except (TypeError, ValueError):
+        raise ValueError('Invalid page reorder payload')
+
+    all_ids = list(ordered_queryset().values_list('id', flat=True))
+    start = (page - 1) * page_size
+    end = start + page_size
+    current_slice = all_ids[start:end]
+
+    if sorted(page_ordered_ids) != sorted(current_slice):
+        raise ValueError('page_ordered_ids must be a permutation of the current page')
+
+    all_ids[start:start + len(page_ordered_ids)] = page_ordered_ids
+    return apply_ordered_ids(all_ids)
+
+
+def move_rule(rule_id, direction):
+    """
+    Move a rule one step up or down in the global order.
+    direction: 'up' | 'down'
+    """
+    direction = (direction or '').strip().lower()
+    if direction not in ('up', 'down'):
+        raise ValueError("direction must be 'up' or 'down'")
+
+    try:
+        rule_id = int(rule_id)
+    except (TypeError, ValueError):
+        raise ValueError('Invalid rule id')
+
+    ids = list(ordered_queryset().values_list('id', flat=True))
+    if rule_id not in ids:
+        raise ValueError('Rule not found')
+
+    idx = ids.index(rule_id)
+    if direction == 'up':
+        if idx == 0:
+            return ids
+        ids[idx - 1], ids[idx] = ids[idx], ids[idx - 1]
+    else:
+        if idx >= len(ids) - 1:
+            return ids
+        ids[idx + 1], ids[idx] = ids[idx], ids[idx + 1]
+
+    return apply_ordered_ids(ids)

--- a/firewall/static/firewall/firewall.js
+++ b/firewall/static/firewall/firewall.js
@@ -2,24 +2,570 @@
  * Created by usman on 9/5/17.
  */
 
+// Helper function to get CSRF token cookie
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+/**
+ * Confirm destructive firewall actions.
+ * Prefers PNotify confirm (Docker Manager pattern); falls back to window.confirm.
+ */
+function firewallConfirmDelete(title, text, onConfirm) {
+    var msg = text || 'Are you sure?';
+    if (typeof PNotify !== 'undefined') {
+        try {
+            (new PNotify({
+                title: title || 'Confirmation Needed',
+                text: msg,
+                icon: 'fa fa-question-circle',
+                hide: false,
+                confirm: {
+                    confirm: true
+                },
+                buttons: {
+                    closer: false,
+                    sticker: false
+                },
+                history: {
+                    history: false
+                }
+            })).get().on('pnotify.confirm', function () {
+                if (typeof onConfirm === 'function') {
+                    onConfirm();
+                }
+            });
+            return;
+        } catch (e) {
+            /* fall through to window.confirm */
+        }
+    }
+    if (window.confirm(msg) && typeof onConfirm === 'function') {
+        onConfirm();
+    }
+}
 
 /* Java script code to ADD Firewall Rules */
 
-app.controller('firewallController', function ($scope, $http) {
+app.controller('firewallController', function ($scope, $http, $timeout) {
 
     $scope.rulesLoading = true;
+    /** Incremented on each rules fetch; stale HTTP responses must not touch rulesLoading. */
+    var rulesFetchGen = 0;
     $scope.actionFailed = true;
     $scope.actionSuccess = true;
+    $scope.showExportFormatModal = false;
+    $scope.showImportFormatModal = false;
+    $scope.exportRulesFormat = 'json';
+    $scope.importRulesFormat = 'json';
+    $scope.showModifyRuleModal = false;
+    $scope.modifyRuleData = { id: null, name: '', proto: 'tcp', port: '', ruleIP: '0.0.0.0/0' };
 
     $scope.canNotAddRule = true;
     $scope.ruleAdded = true;
     $scope.couldNotConnect = true;
     $scope.rulesDetails = false;
 
+    // Initialize rules array - prevents "Cannot read 'length' of undefined" when template evaluates rules.length before API loads
+    $scope.rules = [];
+    // Banned IPs variables – tab from hash so we stay on /firewall/ (avoids 404 on servers without /firewall/firewall-rules/)
+    /* Use window.location.hash only. Angular $location can disagree with the fragment on /firewall/#… and wrongly map to "rules". */
+    function tabFromHash() {
+        var h = String(window.location.hash || '').replace(/^#/, '').toLowerCase();
+        if (h === 'banned-ips' || h === 'banned') return 'banned';
+        if (h === 'trusted-ips' || h === 'ssh-whitelist') return 'trusted';
+        return 'rules';
+    }
+    $scope.activeTab = tabFromHash();
+    $scope.bannedIPs = [];  // Initialize as empty array
+
+    // Re-apply tab from hash after load (hash can be set after controller init in some browsers)
+    function applyTabFromHash() {
+        var tab = tabFromHash();
+        if ($scope.activeTab !== tab) {
+            $scope.activeTab = tab;
+            if (tab === 'banned') { populateBannedIPs(); }
+            else if (tab === 'trusted') { populateTrustedSSHWhitelist(); }
+            else { populateCurrentRecords(); }
+            if (!$scope.$$phase && !$scope.$root.$$phase) { $scope.$apply(); }
+        }
+    }
+    $timeout(applyTabFromHash, 0);
+    if (document.readyState === 'complete') {
+        $timeout(applyTabFromHash, 50);
+    } else {
+        window.addEventListener('load', function() { $timeout(applyTabFromHash, 0); });
+    }
+
+    // Sync tab with hash and load that tab's data on switch (single source of truth from ng-click).
+    $scope.setFirewallTab = function(tab, $event) {
+        if ($event) {
+            try {
+                $event.stopPropagation();
+            } catch (ignoreErr) {}
+        }
+        $timeout(function() {
+            $scope.activeTab = tab;
+            function setHashIfNeeded(frag) {
+                try {
+                    if ((window.location.hash || '') === frag) {
+                        return;
+                    }
+                    var path = window.location.pathname + window.location.search + frag;
+                    if (window.history && typeof window.history.replaceState === 'function') {
+                        window.history.replaceState(null, '', path);
+                    } else {
+                        window.location.hash = frag;
+                    }
+                } catch (ignoreHash) {}
+            }
+            if (tab === 'banned') {
+                setHashIfNeeded('#banned-ips');
+                populateBannedIPs();
+            } else if (tab === 'trusted') {
+                setHashIfNeeded('#trusted-ips');
+                populateTrustedSSHWhitelist();
+            } else {
+                setHashIfNeeded('#rules');
+                populateCurrentRecords();
+            }
+        }, 0);
+    };
+
+    function syncTabFromHash() {
+        var tab = tabFromHash();
+        $scope.$evalAsync(function() {
+            if ($scope.activeTab !== tab) {
+                $scope.activeTab = tab;
+                if (tab === 'banned') { populateBannedIPs(); }
+                else if (tab === 'trusted') { populateTrustedSSHWhitelist(); }
+                else { populateCurrentRecords(); }
+            }
+        });
+    }
+    window.addEventListener('hashchange', syncTabFromHash);
+    
+    // Pagination: Firewall Rules (default 10 per page, options 5–100)
+    $scope.rulesPage = 1;
+    $scope.rulesPageSize = 10;
+    $scope.rulesPageSizeOptions = [5, 10, 20, 30, 50, 100];
+    $scope.rulesTotalCount = 0;
+    
+    // Pagination: Banned IPs
+    $scope.bannedPage = 1;
+    $scope.bannedPageSize = 10;
+    $scope.bannedPageSizeOptions = [5, 10, 20, 30, 50, 100];
+    $scope.bannedTotalCount = 0;
+
+    // Modify Banned IP modal state
+    $scope.showModifyModal = false;
+    $scope.modifyBannedIPData = { ip: '', id: null, reason: '', duration: '24h' };
+    
+    // Initialize banned IPs array - start as null so template shows empty state
+    // Will be set to array after API call
+    $scope.bannedIPsLoading = false;
+    $scope.bannedIPActionFailed = true;
+    $scope.bannedIPActionSuccess = true;
+    $scope.bannedIPCouldNotConnect = true;
+    $scope.banIP = '';
+    $scope.banReason = '';
+    $scope.banDuration = '24h';
+    $scope.trustedSSHWhitelist = [];
+    $scope.trustedForm = { ip: '', label: '' };
+    $scope.trustedSSHLoading = false;
+    $scope.bannedIPSearch = '';
+    $scope.searchBannedIPFilter = function(item) {
+        var q = ($scope.bannedIPSearch || '').toLowerCase().trim();
+        if (!q) return true;
+        var ip = (item.ip || '').toLowerCase();
+        var reason = (item.reason || '').toLowerCase();
+        var status = item.active ? 'active' : 'expired';
+        return ip.indexOf(q) !== -1 || reason.indexOf(q) !== -1 || status.indexOf(q) !== -1;
+    };
+
+    $scope.onBannedSearchChange = function() {
+        if ($scope.bannedSearchTimeout) $timeout.cancel($scope.bannedSearchTimeout);
+        $scope.bannedSearchTimeout = $timeout(function() {
+            $scope.bannedPage = 1;
+            if (typeof populateBannedIPs === 'function') populateBannedIPs();
+        }, 350);
+    };
+
+    $scope.runBannedSearch = function() {
+        $scope.bannedPage = 1;
+        if (typeof populateBannedIPs === 'function') populateBannedIPs();
+    };
+
     firewallStatus();
 
-    populateCurrentRecords();
+    // Load active tab data on init (avoid flipping UX by always prefetching banned).
+    if ($scope.activeTab === 'banned') {
+        populateBannedIPs();
+    } else if ($scope.activeTab === 'trusted') {
+        populateTrustedSSHWhitelist();
+    } else {
+        populateCurrentRecords();
+    }
 
+    $scope.$watch('activeTab', function(newVal, oldVal) {
+        if (newVal === oldVal || !newVal) return;
+        $timeout(function() {
+            try {
+                if (newVal === 'banned' && typeof populateBannedIPs === 'function') populateBannedIPs();
+                else if (newVal === 'trusted' && typeof populateTrustedSSHWhitelist === 'function') populateTrustedSSHWhitelist();
+                else if (newVal === 'rules' && typeof populateCurrentRecords === 'function') populateCurrentRecords();
+            } catch (e) {}
+        }, 0);
+    });
+
+    // Log for debugging
+    console.log('=== FIREWALL CONTROLLER INITIALIZING ===');
+    console.log('Initializing firewall controller, loading banned IPs...');
+    
+    // Define populateBannedIPs function first, then call it
+    // This ensures the function is available when setTimeout executes
+    function populateBannedIPs() {
+        console.log('=== populateBannedIPs() START ===');
+        console.log('Current scope.bannedIPs:', $scope.bannedIPs);
+        console.log('Current activeTab:', $scope.activeTab);
+        
+        $scope.bannedIPsLoading = true;
+        var url = "/firewall/getBannedIPs";
+        var csrfToken = getCookie('csrftoken');
+        var config = {
+            headers: {
+                'X-CSRFToken': csrfToken
+            }
+        };
+
+        var postData = {
+            page: Math.max(1, parseInt($scope.bannedPage, 10) || 1),
+            page_size: Math.max(5, Math.min(100, parseInt($scope.bannedPageSize, 10) || 10)),
+            search: ($scope.bannedIPSearch || '').trim()
+        };
+        console.log('Making request to:', url, 'page:', postData.page, 'page_size:', postData.page_size, 'search:', postData.search);
+        console.log('CSRF Token:', csrfToken ? 'Found (' + csrfToken.substring(0, 10) + '...)' : 'MISSING!');
+        
+        $http.post(url, postData, config).then(
+            function(response) {
+                var res = (typeof response.data === 'string') ? (function() { try { return JSON.parse(response.data); } catch (e) { return {}; } })() : response.data;
+                console.log('=== API RESPONSE RECEIVED ===');
+                console.log('Response status:', response.status);
+                console.log('Response data (parsed):', res);
+                
+                $scope.bannedIPsLoading = false;
+                // Reset error flags
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
+                
+                if (res && res.status === 1) {
+                    var bannedIPsArray = res.bannedIPs || [];
+                    console.log('Raw bannedIPs from API:', bannedIPsArray);
+                    console.log('Banned IPs count:', bannedIPsArray.length);
+                    console.log('Is array?', Array.isArray(bannedIPsArray));
+                    
+                    // Ensure it's an array
+                    if (!Array.isArray(bannedIPsArray)) {
+                        console.error('ERROR: bannedIPs is not an array:', typeof bannedIPsArray);
+                        bannedIPsArray = [];
+                    }
+                    
+                    // Assign to scope - Angular $http callbacks already run within $apply
+                    console.log('Assigning to scope.bannedIPs...');
+                    $scope.bannedIPs = bannedIPsArray;
+                    $scope.bannedTotalCount = res.total_count != null ? res.total_count : bannedIPsArray.length;
+                    $scope.bannedPage = Math.max(1, res.page != null ? res.page : 1);
+                    $scope.bannedPageSize = res.page_size != null ? res.page_size : 10;
+                    $scope.bannedPageInput = $scope.bannedPage;
+                    console.log('After assignment - scope.bannedIPs:', $scope.bannedIPs);
+                    console.log('After assignment - scope.bannedIPs.length:', $scope.bannedIPs ? $scope.bannedIPs.length : 'undefined');
+                    console.log('After assignment - activeTab:', $scope.activeTab);
+                    
+                    // No need to call $apply - $http callbacks run within $apply automatically
+                    console.log('View should update automatically (Angular $http handles $apply)');
+                    
+                    console.log('=== populateBannedIPs() SUCCESS ===');
+                } else {
+                    console.error('ERROR: API returned status !== 1');
+                    console.error('Response data:', res);
+                    $scope.bannedIPs = [];
+                    $scope.bannedIPActionFailed = false;
+                    $scope.bannedIPErrorMessage = (res && res.error_message) || 'Unknown error';
+                }
+            },
+            function(error) {
+                console.error('=== HTTP ERROR ===');
+                console.error('Error object:', error);
+                console.error('Error status:', error.status);
+                console.error('Error data:', error.data);
+                console.error('Error statusText:', error.statusText);
+                
+                $scope.bannedIPsLoading = false;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = false;
+                $scope.bannedIPs = [];
+                
+                try {
+                    if (!$scope.$$phase && !$scope.$root.$$phase) {
+                        $scope.$apply();
+                    }
+                } catch(e) {
+                    console.error('Error in $apply (error handler):', e);
+                }
+            }
+        );
+    }
+
+    function populateTrustedSSHWhitelist() {
+        $scope.trustedSSHLoading = true;
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+        $http.post('/base/sshSecurityWhitelistList', {}, config).then(
+            function(response) {
+                $scope.trustedSSHLoading = false;
+                var res = response.data;
+                if (typeof res === 'string') {
+                    try { res = JSON.parse(res); } catch (e) { res = {}; }
+                }
+                if (res && res.status === 1) {
+                    var ent = res.entries || [];
+                    $scope.trustedSSHWhitelist = ent.map(function(e) {
+                        return {
+                            ip: e.ip,
+                            label: e.label || '',
+                            updated: e.updated || 0,
+                            _l: e.label || '',
+                            _nip: ''
+                        };
+                    });
+                } else {
+                    $scope.trustedSSHWhitelist = [];
+                    var errMsg = (res && res.error) ? res.error : 'Could not load trusted IPs';
+                    if (typeof PNotify !== 'undefined') {
+                        new PNotify({ title: 'Trusted IPs', text: errMsg, type: 'error', delay: 6000 });
+                    }
+                }
+            },
+            function(error) {
+                $scope.trustedSSHLoading = false;
+                $scope.trustedSSHWhitelist = [];
+                var msg = (error.data && error.data.error) ? error.data.error : 'Request failed';
+                if (typeof PNotify !== 'undefined') {
+                    new PNotify({ title: 'Trusted IPs', text: msg, type: 'error', delay: 6000 });
+                }
+            }
+        );
+    }
+
+    $scope.populateTrustedSSHWhitelist = function() {
+        populateTrustedSSHWhitelist();
+    };
+
+    $scope.addTrustedSSHWhitelist = function() {
+        var ip = ($scope.trustedForm.ip || '').trim();
+        var label = ($scope.trustedForm.label || '').trim();
+        if (!ip) {
+            if (typeof PNotify !== 'undefined') {
+                new PNotify({ title: 'Trusted IPs', text: 'Enter an IP address', type: 'warning', delay: 5000 });
+            }
+            return;
+        }
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+        $http.post('/base/sshSecurityWhitelistAdd', { ip: ip, label: label }, config).then(
+            function(response) {
+                var res = response.data;
+                if (typeof res === 'string') {
+                    try { res = JSON.parse(res); } catch (e) { res = {}; }
+                }
+                if (res && res.status === 1) {
+                    $scope.trustedForm.ip = '';
+                    $scope.trustedForm.label = '';
+                    populateTrustedSSHWhitelist();
+                    if (typeof PNotify !== 'undefined') {
+                        new PNotify({ title: 'Trusted IPs', text: 'IP added to trusted list', type: 'success', delay: 4000 });
+                    }
+                } else {
+                    var errAdd = (res && res.error) ? res.error : 'Failed to add';
+                    if (typeof PNotify !== 'undefined') {
+                        new PNotify({ title: 'Trusted IPs', text: errAdd, type: 'error', delay: 6000 });
+                    }
+                }
+            },
+            function(err) {
+                var em = (err.data && err.data.error) ? err.data.error : 'Request failed';
+                if (typeof PNotify !== 'undefined') {
+                    new PNotify({ title: 'Trusted IPs', text: em, type: 'error', delay: 6000 });
+                }
+            }
+        );
+    };
+
+    $scope.removeTrustedSSHWhitelist = function(ip) {
+        if (!ip) return;
+        firewallConfirmDelete(
+            'Remove Trusted IP',
+            'Are you sure you want to remove trusted SSH IP "' + ip + '" from the whitelist?',
+            function () {
+                var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+                $http.post('/base/sshSecurityWhitelistRemove', { ip: ip }, config).then(
+                    function(response) {
+                        var res = response.data;
+                        if (typeof res === 'string') {
+                            try { res = JSON.parse(res); } catch (e) { res = {}; }
+                        }
+                        if (res && res.status === 1) {
+                            populateTrustedSSHWhitelist();
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: 'IP removed', type: 'success', delay: 4000 });
+                            }
+                        } else {
+                            var errRm = (res && res.error) ? res.error : 'Failed to remove';
+                            if (typeof PNotify !== 'undefined') {
+                                new PNotify({ title: 'Trusted IPs', text: errRm, type: 'error', delay: 6000 });
+                            }
+                        }
+                    },
+                    function(err) {
+                        var em2 = (err.data && err.data.error) ? err.data.error : 'Request failed';
+                        if (typeof PNotify !== 'undefined') {
+                            new PNotify({ title: 'Trusted IPs', text: em2, type: 'error', delay: 6000 });
+                        }
+                    }
+                );
+            }
+        );
+    };
+
+    $scope.saveTrustedSSHWhitelistRow = function(row) {
+        if (!row || !row.ip) return;
+        var payload = { ip: row.ip, label: row._l };
+        if (row._nip && String(row._nip).trim()) {
+            payload.new_ip = String(row._nip).trim();
+        }
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') || '' } };
+        $http.post('/base/sshSecurityWhitelistUpdate', payload, config).then(
+            function(response) {
+                var res = response.data;
+                if (typeof res === 'string') {
+                    try { res = JSON.parse(res); } catch (e) { res = {}; }
+                }
+                var ok = res && (res.status === 1 || res.status === '1');
+                if (ok) {
+                    populateTrustedSSHWhitelist();
+                    if (typeof PNotify !== 'undefined') {
+                        var unchanged = res.unchanged === true || res.unchanged === 'true' || res.unchanged === 1;
+                        var msgOk = (res.message && String(res.message).length) ? res.message : (unchanged ? 'No changes to save.' : 'Entry updated');
+                        new PNotify({ title: 'Trusted IPs', text: msgOk, type: unchanged ? 'info' : 'success', delay: 4000 });
+                    }
+                } else {
+                    var errUp = (res && res.error) ? res.error : 'Failed to update';
+                    if (typeof PNotify !== 'undefined') {
+                        new PNotify({ title: 'Trusted IPs', text: errUp, type: 'error', delay: 6000 });
+                    }
+                }
+            },
+            function(err) {
+                var em3 = (err.data && err.data.error) ? err.data.error : 'Request failed';
+                if (typeof PNotify !== 'undefined') {
+                    new PNotify({ title: 'Trusted IPs', text: em3, type: 'error', delay: 6000 });
+                }
+            }
+        );
+    };
+    
+    // Expose to scope for template access
+    $scope.populateBannedIPs = function() {
+        console.log('$scope.populateBannedIPs() called from template');
+        populateBannedIPs();
+    };
+
+    $scope.goToBannedPage = function(page) {
+        var totalP = Math.max(1, $scope.bannedTotalPages());
+        var p = parseInt(page, 10);
+        if (isNaN(p) || p < 1 || p > totalP) return;
+        $scope.bannedPage = p;
+        populateBannedIPs();
+    };
+    $scope.goToBannedPageByInput = function() {
+        var self = $scope;
+        $timeout(function() {
+            var n = parseInt(self.bannedPageInput, 10);
+            if (isNaN(n) || n < 1) n = self.bannedPage || 1;
+            var maxP = Math.max(1, self.bannedTotalPages());
+            n = Math.min(Math.max(1, n), maxP);
+            self.bannedPageInput = n;
+            self.bannedPage = n;
+            populateBannedIPs();
+        }, 0);
+    };
+    $scope.bannedTotalPages = function() {
+        var size = $scope.bannedPageSize || 10;
+        var total = $scope.bannedTotalCount || ($scope.bannedIPs ? $scope.bannedIPs.length : 0) || 0;
+        return size > 0 ? Math.max(1, Math.ceil(total / size)) : 1;
+    };
+    $scope.bannedRangeStart = function() {
+        var total = $scope.bannedTotalCount || ($scope.bannedIPs ? $scope.bannedIPs.length : 0) || 0;
+        if (total === 0) return 0;
+        var page = Math.max(1, $scope.bannedPage || 1);
+        var size = $scope.bannedPageSize || 10;
+        return (page - 1) * size + 1;
+    };
+    $scope.bannedRangeEnd = function() {
+        var start = $scope.bannedRangeStart();
+        var size = $scope.bannedPageSize || 10;
+        var total = $scope.bannedTotalCount || ($scope.bannedIPs ? $scope.bannedIPs.length : 0) || 0;
+        return total === 0 ? 0 : Math.min(start + size - 1, total);
+    };
+    $scope.setBannedPageSize = function() {
+        var size = parseInt($scope.bannedPageSize, 10);
+        $scope.bannedPageSize = (size >= 5 && size <= 100) ? size : 10;
+        $scope.bannedPage = 1;
+        populateBannedIPs();
+    };
+
+    if (typeof window !== 'undefined') {
+        window.__firewallLoadTab = function(tab) {
+            $scope.$evalAsync(function() {
+                $scope.activeTab = tab;
+                if (tab === 'banned') { populateBannedIPs(); }
+                else if (tab === 'trusted') { populateTrustedSSHWhitelist(); }
+                else { populateCurrentRecords(); }
+            });
+        };
+    }
+    
+    // Prefetch banned IPs shortly after load only when that tab is active (avoids tab race noise).
+    try {
+        $timeout(function() {
+            try {
+                if ($scope.activeTab === 'banned') {
+                    console.log('=== Calling populateBannedIPs from $timeout on page load ===');
+                    populateBannedIPs();
+                } else if ($scope.activeTab === 'rules') {
+                    populateCurrentRecords();
+                } else if ($scope.activeTab === 'trusted') {
+                    populateTrustedSSHWhitelist();
+                }
+            } catch(e) {
+                console.error('Error in firewall tab prefetch from timeout:', e);
+            }
+        }, 500);
+    } catch(e) {
+        console.error('Error setting up timeout for firewall tab prefetch:', e);
+    }
+    
     $scope.addRule = function () {
 
         $scope.rulesLoading = false;
@@ -64,7 +610,6 @@ app.controller('firewallController', function ($scope, $http) {
 
                 populateCurrentRecords();
 
-                $scope.rulesLoading = true;
                 $scope.actionFailed = true;
                 $scope.actionSuccess = true;
 
@@ -76,7 +621,7 @@ app.controller('firewallController', function ($scope, $http) {
             }
             else {
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = true;
                 $scope.actionSuccess = true;
 
@@ -92,7 +637,7 @@ app.controller('firewallController', function ($scope, $http) {
 
         function cantLoadInitialDatas(response) {
 
-            $scope.rulesLoading = true;
+            $scope.rulesLoading = false;
             $scope.actionFailed = true;
             $scope.actionSuccess = true;
 
@@ -106,114 +651,437 @@ app.controller('firewallController', function ($scope, $http) {
     };
 
     function populateCurrentRecords() {
-
-        $scope.rulesLoading = false;
+        var gen = ++rulesFetchGen;
+        $scope.rulesLoading = true;
         $scope.actionFailed = true;
         $scope.actionSuccess = true;
 
-
         url = "/firewall/getCurrentRules";
-
-        var data = {};
-
+        var data = {
+            page: Math.max(1, parseInt($scope.rulesPage, 10) || 1),
+            page_size: Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10))
+        };
         var config = {
             headers: {
                 'X-CSRFToken': getCookie('csrftoken')
             }
         };
 
-
         $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
 
-
         function ListInitialDatas(response) {
-            if (response.data.fetchStatus === 1) {
-                $scope.rules = JSON.parse(response.data.data);
-                $scope.rulesLoading = true;
+            if (gen !== rulesFetchGen) {
+                return;
             }
-            else {
-                $scope.rulesLoading = true;
-                $scope.errorMessage = response.data.error_message;
+            try {
+                var res = (typeof response.data === 'string') ? (function() { try { return JSON.parse(response.data); } catch (e) { return {}; } })() : response.data;
+                if (res && res.fetchStatus == 1) {
+                    var parsedRules = [];
+                    if (typeof res.data === 'string') {
+                        try {
+                            parsedRules = JSON.parse(res.data);
+                        } catch (parseErr) {
+                            parsedRules = [];
+                            $scope.errorMessage = (res && res.error_message) ? res.error_message : 'Invalid rules data';
+                        }
+                    } else {
+                        parsedRules = res.data || [];
+                    }
+                    $scope.rules = parsedRules;
+                    $scope.rulesTotalCount = res.total_count != null ? res.total_count : ($scope.rules ? $scope.rules.length : 0);
+                    $scope.rulesPage = Math.max(1, res.page != null ? res.page : 1);
+                    $scope.rulesPageSize = res.page_size != null ? res.page_size : 10;
+                } else {
+                    $scope.errorMessage = (res && res.error_message) ? res.error_message : '';
+                }
+            } catch (e) {
+                $scope.errorMessage = 'Could not load firewall rules.';
+            } finally {
+                if (gen === rulesFetchGen) {
+                    $scope.rulesLoading = false;
+                }
             }
         }
 
         function cantLoadInitialDatas(response) {
+            if (gen !== rulesFetchGen) {
+                return;
+            }
+            $scope.rulesLoading = false;
             $scope.couldNotConnect = false;
-
         }
+    }
 
+    $scope.goToRulesPage = function(page) {
+        var totalP = Math.max(1, $scope.rulesTotalPages());
+        var p = parseInt(page, 10);
+        if (isNaN(p) || p < 1 || p > totalP) return;
+        $scope.rulesPage = p;
+        populateCurrentRecords();
+    };
+    $scope.goToRulesPageByInput = function() {
+        $timeout(function() {
+            var n = parseInt($scope.rulesPageInput, 10);
+            if (isNaN(n) || n < 1) n = $scope.rulesPage || 1;
+            var maxP = Math.max(1, $scope.rulesTotalPages());
+            n = Math.min(Math.max(1, n), maxP);
+            $scope.rulesPageInput = n;
+            $scope.rulesPage = n;
+            populateCurrentRecords();
+        }, 0);
+    };
+    $scope.rulesTotalPages = function() {
+        var size = $scope.rulesPageSize || 10;
+        var total = $scope.rulesTotalCount || ($scope.rules && $scope.rules.length) || 0;
+        return size > 0 ? Math.max(1, Math.ceil(total / size)) : 1;
+    };
+    $scope.rulesRangeStart = function() {
+        var total = $scope.rulesTotalCount || ($scope.rules && $scope.rules.length) || 0;
+        if (total === 0) return 0;
+        var page = Math.max(1, $scope.rulesPage || 1);
+        var size = $scope.rulesPageSize || 10;
+        return (page - 1) * size + 1;
+    };
+    $scope.rulesRangeEnd = function() {
+        var start = $scope.rulesRangeStart();
+        var size = $scope.rulesPageSize || 10;
+        var total = $scope.rulesTotalCount || ($scope.rules && $scope.rules.length) || 0;
+        return total === 0 ? 0 : Math.min(start + size - 1, total);
+    };
+    $scope.setRulesPageSize = function() {
+        var size = parseInt($scope.rulesPageSize, 10);
+        $scope.rulesPageSize = (size >= 5 && size <= 100) ? size : 10;
+        $scope.rulesPage = 1;
+        populateCurrentRecords();
     };
 
-    $scope.deleteRule = function (id, proto, port, ruleIP) {
+    function renumberDisplayedRuleIds() {
+        var start = $scope.rulesRangeStart() || 1;
+        ($scope.rules || []).forEach(function(rule, idx) {
+            rule.displayId = start + idx;
+            rule.sortOrder = rule.displayId;
+        });
+    }
 
-        $scope.rulesLoading = false;
-
-        url = "/firewall/deleteRule";
-
+    function persistPageRuleOrder() {
+        var pageIds = ($scope.rules || []).map(function(r) { return r.id; });
+        if (!pageIds.length) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
         var data = {
-            id: id,
-            proto: proto,
-            port: port,
-            ruleIP: ruleIP
+            page_ordered_ids: pageIds,
+            page: Math.max(1, parseInt($scope.rulesPage, 10) || 1),
+            page_size: Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10))
         };
-
-        var config = {
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken')
-            }
-        };
-
-
-        $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
-
-
-        function ListInitialDatas(response) {
-
-
-            if (response.data.delete_status === 1) {
-
-
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                renumberDisplayedRuleIds();
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                $scope.rulesLoading = false;
+            } else {
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not save rule order';
                 populateCurrentRecords();
-                $scope.rulesLoading = true;
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = true;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-
             }
-            else {
-
-                $scope.rulesLoading = true;
-                $scope.actionFailed = true;
-                $scope.actionSuccess = true;
-
-                $scope.canNotAddRule = false;
-                $scope.ruleAdded = true;
-                $scope.couldNotConnect = true;
-
-                $scope.rulesLoading = true;
-                $scope.errorMessage = response.data.error_message;
-
-
-            }
-
-        }
-
-        function cantLoadInitialDatas(response) {
-
-            $scope.rulesLoading = true;
-            $scope.actionFailed = true;
+        }, function() {
+            $scope.actionFailed = false;
             $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+            populateCurrentRecords();
+        });
+    }
 
-            $scope.canNotAddRule = true;
-            $scope.ruleAdded = true;
-            $scope.couldNotConnect = false;
+    $scope.canMoveRuleUp = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        return !(page === 1 && index === 0);
+    };
 
+    $scope.canMoveRuleDown = function(index) {
+        var page = Math.max(1, parseInt($scope.rulesPage, 10) || 1);
+        var size = Math.max(5, Math.min(100, parseInt($scope.rulesPageSize, 10) || 10));
+        var total = $scope.rulesTotalCount || ($scope.rules ? $scope.rules.length : 0) || 0;
+        var globalIndex = (page - 1) * size + index;
+        return globalIndex < (total - 1);
+    };
 
+    $scope.moveRuleUp = function(rule) {
+        if (!rule || !rule.id) {
+            return;
         }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'up' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    $scope.moveRuleDown = function(rule) {
+        if (!rule || !rule.id) {
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/reorderRules';
+        var data = { id: rule.id, direction: 'down' };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            var res = response.data || {};
+            if (res.reorder_status === 1 || res.status === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = res.error_message || 'Could not move rule';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    var rulesDragFromIndex = null;
+
+    function bindRulesDragDrop() {
+        var tbody = document.getElementById('firewall-rules-tbody');
+        if (!tbody || tbody.getAttribute('data-dnd-bound') === '1') {
+            return;
+        }
+        tbody.setAttribute('data-dnd-bound', '1');
+
+        tbody.addEventListener('dragstart', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            // Allow drag from row/handle; block from action buttons/inputs
+            if (ev.target.closest && ev.target.closest('button, a, input, select, textarea')) {
+                ev.preventDefault();
+                return;
+            }
+            rulesDragFromIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            if (isNaN(rulesDragFromIndex)) {
+                rulesDragFromIndex = null;
+                return;
+            }
+            row.classList.add('rule-row-dragging');
+            try {
+                ev.dataTransfer.effectAllowed = 'move';
+                ev.dataTransfer.setData('text/plain', String(rulesDragFromIndex));
+            } catch (ignoreSet) {}
+        });
+
+        tbody.addEventListener('dragover', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            try {
+                ev.dataTransfer.dropEffect = 'move';
+            } catch (ignoreDrop) {}
+        });
+
+        tbody.addEventListener('drop', function(ev) {
+            var row = ev.target && ev.target.closest ? ev.target.closest('tr[data-rule-id]') : null;
+            if (!row || !tbody.contains(row)) {
+                return;
+            }
+            ev.preventDefault();
+            var toIndex = parseInt(row.getAttribute('data-rule-index'), 10);
+            var fromIndex = rulesDragFromIndex;
+            if (fromIndex === null || isNaN(toIndex) || fromIndex === toIndex) {
+                return;
+            }
+            $scope.$applyAsync(function() {
+                var list = $scope.rules || [];
+                if (fromIndex < 0 || fromIndex >= list.length || toIndex < 0 || toIndex >= list.length) {
+                    return;
+                }
+                var moved = list.splice(fromIndex, 1)[0];
+                list.splice(toIndex, 0, moved);
+                $scope.rules = list;
+                renumberDisplayedRuleIds();
+                persistPageRuleOrder();
+            });
+        });
+
+        tbody.addEventListener('dragend', function(ev) {
+            rulesDragFromIndex = null;
+            var dragging = tbody.querySelectorAll('.rule-row-dragging');
+            for (var i = 0; i < dragging.length; i++) {
+                dragging[i].classList.remove('rule-row-dragging');
+            }
+        });
+    }
+
+    // Bind after Angular paints the rules table (tbody is destroyed when rules empty)
+    $scope.$watchCollection('rules', function() {
+        $timeout(bindRulesDragDrop, 0);
+    });
+
+    $scope.openModifyRuleModal = function(rule) {
+        if (!rule) return;
+        $scope.modifyRuleData = {
+            id: rule.id,
+            name: rule.name || '',
+            proto: rule.proto || 'tcp',
+            port: String(rule.port || ''),
+            ruleIP: rule.ipAddress || rule.ruleIP || '0.0.0.0/0'
+        };
+        $scope.showModifyRuleModal = true;
+    };
+
+    $scope.closeModifyRuleModal = function() {
+        $scope.showModifyRuleModal = false;
+        $scope.modifyRuleData = { id: null, name: '', proto: 'tcp', port: '', ruleIP: '0.0.0.0/0' };
+    };
+
+    $scope.saveModifyRule = function() {
+        var d = $scope.modifyRuleData;
+        if (!d.name || !d.name.trim()) {
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Rule name is required';
+            return;
+        }
+        if (!d.port || !String(d.port).trim()) {
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Port is required';
+            return;
+        }
+        $scope.rulesLoading = true;
+        var url = '/firewall/modifyRule';
+        var data = {
+            id: d.id,
+            name: d.name.trim(),
+            proto: d.proto || 'tcp',
+            port: String(d.port).trim(),
+            ruleIP: (d.ruleIP || '0.0.0.0/0').trim()
+        };
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            if (response.data && response.data.status === 1) {
+                $scope.closeModifyRuleModal();
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+            } else {
+                $scope.rulesLoading = false;
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = (response.data && response.data.error_message) || 'Modify failed';
+            }
+        }, function() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = 'Could not connect to server. Please refresh this page.';
+        });
+    };
+
+    $scope.deleteRule = function (id, proto, port, ruleIP, ruleName) {
+        var nameLabel = (ruleName && String(ruleName).trim()) ? String(ruleName).trim() : ('#' + id);
+        var detail = nameLabel + ' (' + (proto || '') + '/' + (port || '') + ', ' + (ruleIP || '') + ')';
+        firewallConfirmDelete(
+            'Delete Firewall Rule',
+            'Are you sure you want to delete firewall rule "' + detail + '"? This cannot be undone.',
+            function () {
+                $scope.rulesLoading = true;
+
+                url = "/firewall/deleteRule";
+
+                var data = {
+                    id: id,
+                    proto: proto,
+                    port: port,
+                    ruleIP: ruleIP
+                };
+
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
+
+
+                $http.post(url, data, config).then(ListInitialDatas, cantLoadInitialDatas);
+
+
+                function ListInitialDatas(response) {
+
+
+                    if (response.data.delete_status === 1) {
+
+
+                        populateCurrentRecords();
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = true;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+
+                    }
+                    else {
+
+                        $scope.rulesLoading = false;
+                        $scope.actionFailed = true;
+                        $scope.actionSuccess = true;
+
+                        $scope.canNotAddRule = false;
+                        $scope.ruleAdded = true;
+                        $scope.couldNotConnect = true;
+
+                        $scope.errorMessage = response.data.error_message;
+
+
+                    }
+
+                }
+
+                function cantLoadInitialDatas(response) {
+
+                    $scope.rulesLoading = false;
+                    $scope.actionFailed = true;
+                    $scope.actionSuccess = true;
+
+                    $scope.canNotAddRule = true;
+                    $scope.ruleAdded = true;
+                    $scope.couldNotConnect = false;
+
+
+                }
+            }
+        );
 
 
     };
@@ -251,7 +1119,7 @@ app.controller('firewallController', function ($scope, $http) {
             if (response.data.reload_status == 1) {
 
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = true;
                 $scope.actionSuccess = false;
 
@@ -259,11 +1127,14 @@ app.controller('firewallController', function ($scope, $http) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
+                $scope.rulesDetails = false;
+                populateCurrentRecords();
+
 
             }
             else {
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = false;
                 $scope.actionSuccess = true;
 
@@ -280,7 +1151,7 @@ app.controller('firewallController', function ($scope, $http) {
 
         function cantLoadInitialDatas(response) {
 
-            $scope.rulesLoading = true;
+            $scope.rulesLoading = false;
             $scope.actionFailed = true;
             $scope.actionSuccess = true;
 
@@ -326,7 +1197,7 @@ app.controller('firewallController', function ($scope, $http) {
             if (response.data.start_status == 1) {
 
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = true;
                 $scope.actionSuccess = false;
 
@@ -337,12 +1208,14 @@ app.controller('firewallController', function ($scope, $http) {
                 $scope.rulesDetails = false;
 
                 firewallStatus();
+                /* Reload rules after Start so the table stays visible and populated. */
+                populateCurrentRecords();
 
 
             }
             else {
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = false;
                 $scope.actionSuccess = true;
 
@@ -359,7 +1232,7 @@ app.controller('firewallController', function ($scope, $http) {
 
         function cantLoadInitialDatas(response) {
 
-            $scope.rulesLoading = true;
+            $scope.rulesLoading = false;
             $scope.actionFailed = true;
             $scope.actionSuccess = true;
 
@@ -406,7 +1279,7 @@ app.controller('firewallController', function ($scope, $http) {
             if (response.data.stop_status == 1) {
 
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = true;
                 $scope.actionSuccess = false;
 
@@ -414,15 +1287,17 @@ app.controller('firewallController', function ($scope, $http) {
                 $scope.ruleAdded = true;
                 $scope.couldNotConnect = true;
 
-                $scope.rulesDetails = true;
+                /* Keep rules UI visible while firewall is stopped so operators can still edit stored rules. */
+                $scope.rulesDetails = false;
 
                 firewallStatus();
+                populateCurrentRecords();
 
 
             }
             else {
 
-                $scope.rulesLoading = true;
+                $scope.rulesLoading = false;
                 $scope.actionFailed = false;
                 $scope.actionSuccess = true;
 
@@ -439,7 +1314,7 @@ app.controller('firewallController', function ($scope, $http) {
 
         function cantLoadInitialDatas(response) {
 
-            $scope.rulesLoading = true;
+            $scope.rulesLoading = false;
             $scope.actionFailed = true;
             $scope.actionSuccess = true;
 
@@ -477,19 +1352,17 @@ app.controller('firewallController', function ($scope, $http) {
             if (response.data.status == 1) {
 
                 if (response.data.firewallStatus == 1) {
-                    $scope.rulesDetails = false;
                     $scope.status = "ON";
                 }
                 else {
-                    $scope.rulesDetails = true;
                     $scope.status = "OFF";
                 }
             }
             else {
-
-                $scope.rulesDetails = true;
                 $scope.status = "OFF";
             }
+            /* Never hide the rules table/form when firewall is OFF (was rulesDetails=true). */
+            $scope.rulesDetails = false;
 
 
         }
@@ -501,10 +1374,419 @@ app.controller('firewallController', function ($scope, $http) {
 
         }
 
+    }
+
+    // Banned IPs Functions
+    $scope.addBannedIP = function() {
+        if (!$scope.banIP || !$scope.banReason) {
+            $scope.bannedIPActionFailed = false;
+            $scope.bannedIPErrorMessage = "Please fill in all required fields";
+            return;
+        }
+
+        $scope.bannedIPsLoading = true;
+        $scope.bannedIPActionFailed = true;
+        $scope.bannedIPActionSuccess = true;
+        $scope.bannedIPCouldNotConnect = true;
+
+        var data = {
+            ip: $scope.banIP,
+            reason: $scope.banReason,
+            duration: $scope.banDuration
+        };
+
+        var url = "/firewall/addBannedIP";
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(function(response) {
+            $scope.bannedIPsLoading = false;
+            // Reset error flags
+            $scope.bannedIPActionFailed = true;
+            $scope.bannedIPActionSuccess = true;
+            $scope.bannedIPCouldNotConnect = true;
+            
+            if (response.data.status === 1) {
+                $scope.bannedIPActionSuccess = false;
+                $scope.banIP = '';
+                $scope.banReason = '';
+                $scope.banDuration = '24h';
+                console.log('IP banned successfully, refreshing list...');
+                populateBannedIPs(); // Refresh the list
+            } else {
+                $scope.bannedIPActionFailed = false;
+                $scope.bannedIPErrorMessage = response.data.error_message || 'Unknown error';
+                console.error('Failed to ban IP:', response.data);
+            }
+        }, function(error) {
+            $scope.bannedIPsLoading = false;
+            $scope.bannedIPActionFailed = true;
+            $scope.bannedIPActionSuccess = true;
+            $scope.bannedIPCouldNotConnect = false;
+            console.error('Error banning IP:', error);
+        });
     };
 
+    $scope.removeBannedIP = function(id, ip) {
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Unban IP Address',
+            'Are you sure you want to unban IP address "' + ipLabel + '"?',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
+
+                var data = { id: id };
+
+                var url = "/firewall/removeBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
+
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
+            }
+        );
+    };
+
+    $scope.deleteBannedIP = function(id, ip) {
+        var ipLabel = ip || ('#' + id);
+        firewallConfirmDelete(
+            'Delete Banned IP Record',
+            'Are you sure you want to permanently delete the record for IP address "' + ipLabel + '"? This action cannot be undone.',
+            function () {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPActionFailed = true;
+                $scope.bannedIPActionSuccess = true;
+                $scope.bannedIPCouldNotConnect = true;
+
+                var data = { id: id };
+
+                var url = "/firewall/deleteBannedIP";
+                var config = {
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                };
+
+                $http.post(url, data, config).then(function(response) {
+                    $scope.bannedIPsLoading = false;
+                    if (response.data.status === 1) {
+                        $scope.bannedIPActionSuccess = false;
+                        populateBannedIPs(); // Refresh the list
+                    } else {
+                        $scope.bannedIPActionFailed = false;
+                        $scope.bannedIPErrorMessage = response.data.error_message;
+                    }
+                }, function(error) {
+                    $scope.bannedIPsLoading = false;
+                    $scope.bannedIPCouldNotConnect = false;
+                });
+            }
+        );
+    };
+
+    $scope.openModifyModal = function(bannedIP) {
+        if (!bannedIP) return;
+        $scope.modifyBannedIPData = {
+            id: bannedIP.id,
+            ip: bannedIP.ip || bannedIP.ip_address || '',
+            reason: bannedIP.reason || '',
+            duration: bannedIP.duration || '24h'
+        };
+        $scope.showModifyModal = true;
+    };
+
+    $scope.closeModifyModal = function() {
+        $scope.showModifyModal = false;
+        $scope.modifyBannedIPData = { ip: '', id: null, reason: '', duration: '24h' };
+    };
+
+    $scope.saveModifyBannedIP = function() {
+        var d = $scope.modifyBannedIPData;
+        if (!d.reason || !d.reason.trim()) {
+            $scope.bannedIPActionFailed = false;
+            $scope.bannedIPErrorMessage = 'Reason is required';
+            return;
+        }
+        $scope.bannedIPsLoading = true;
+        $scope.bannedIPActionFailed = true;
+        $scope.bannedIPActionSuccess = true;
+        $scope.bannedIPCouldNotConnect = true;
+        var data = {
+            id: d.id,
+            ip: d.ip,
+            reason: d.reason.trim(),
+            duration: d.duration || '24h'
+        };
+        var url = '/firewall/modifyBannedIP';
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') } };
+        $http.post(url, data, config).then(function(response) {
+            $scope.bannedIPsLoading = false;
+            if (response.data && response.data.status === 1) {
+                $scope.bannedIPActionSuccess = false;
+                $scope.closeModifyModal();
+                populateBannedIPs();
+            } else {
+                $scope.bannedIPActionFailed = false;
+                $scope.bannedIPErrorMessage = (response.data && response.data.error_message) || 'Modify failed';
+            }
+        }, function(error) {
+            $scope.bannedIPsLoading = false;
+            $scope.bannedIPCouldNotConnect = false;
+        });
+    };
+
+    $scope.exportBannedIPs = function() {
+        $scope.bannedIPsLoading = false;
+        var url = "/firewall/exportBannedIPs";
+        var config = { headers: { 'X-CSRFToken': getCookie('csrftoken') }, responseType: 'text' };
+        $http.post(url, {}, config).then(function(response) {
+            $scope.bannedIPsLoading = true;
+            var raw = response.data;
+            try {
+                var data = typeof raw === 'string' ? JSON.parse(raw) : raw;
+                if (data && data.exportStatus === 0) {
+                    $scope.bannedIPActionFailed = false;
+                    $scope.bannedIPErrorMessage = data.error_message || 'Export failed';
+                    return;
+                }
+            } catch (e) {}
+            var content = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
+            var blob = new Blob([content], { type: 'application/json' });
+            var a = document.createElement('a');
+            a.href = window.URL.createObjectURL(blob);
+            a.download = 'banned_ips_export_' + (Date.now() / 1000 | 0) + '.json';
+            a.click();
+            window.URL.revokeObjectURL(a.href);
+            $scope.bannedIPActionSuccess = false;
+        }, function() {
+            $scope.bannedIPsLoading = true;
+            $scope.bannedIPCouldNotConnect = false;
+        });
+    };
+
+    $scope.importBannedIPs = function() {
+        var input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.json';
+        input.style.display = 'none';
+        input.onchange = function(event) {
+            var file = event.target.files[0];
+            if (!file) return;
+            $scope.bannedIPsLoading = false;
+            var formData = new FormData();
+            formData.append('import_file', file);
+            var config = {
+                headers: { 'X-CSRFToken': getCookie('csrftoken'), 'Content-Type': undefined },
+                transformRequest: angular.identity
+            };
+            $http.post("/firewall/importBannedIPs", formData, config).then(function(response) {
+                $scope.bannedIPsLoading = true;
+                if (response.data && response.data.importStatus === 1) {
+                    $scope.bannedIPActionSuccess = false;
+                    populateBannedIPs();
+                } else {
+                    $scope.bannedIPActionFailed = false;
+                    $scope.bannedIPErrorMessage = (response.data && response.data.error_message) || 'Import failed';
+                }
+            }, function() {
+                $scope.bannedIPsLoading = true;
+                $scope.bannedIPCouldNotConnect = false;
+            });
+        };
+        document.body.appendChild(input);
+        input.click();
+        document.body.removeChild(input);
+    };
+
+    // Export/Import Firewall Rules: format modals and actions
+    $scope.exportRules = function () {
+        $scope.showExportFormatModal = true;
+        $scope.exportRulesFormat = $scope.exportRulesFormat || 'json';
+    };
+
+    $scope.closeExportFormatModal = function () {
+        $scope.showExportFormatModal = false;
+    };
+
+    $scope.confirmExportRules = function () {
+        $scope.showExportFormatModal = false;
+        var format = $scope.exportRulesFormat || 'json';
+        doExportRules(format);
+    };
+
+    function doExportRules(format) {
+        $scope.rulesLoading = true;
+        $scope.actionFailed = true;
+        $scope.actionSuccess = true;
+
+        var url = "/firewall/exportFirewallRules";
+        var data = { format: format };
+        var config = {
+            headers: { 'X-CSRFToken': getCookie('csrftoken') },
+            responseType: 'text'
+        };
+
+        $http.post(url, data, config).then(exportSuccess, exportError);
+
+        function exportSuccess(response) {
+            $scope.rulesLoading = false;
+            var raw = response.data;
+            if (typeof raw === 'string' && raw.indexOf('{') === 0) {
+                try {
+                    var parsed = JSON.parse(raw);
+                    if (parsed.exportStatus === 0) {
+                        $scope.actionFailed = false;
+                        $scope.actionSuccess = true;
+                        $scope.errorMessage = parsed.error_message || 'Export failed';
+                        return;
+                    }
+                } catch (e) {}
+            }
+            var contentType = format === 'excel' ? 'text/csv' : 'application/json';
+            var ext = format === 'excel' ? 'csv' : 'json';
+            var blob = new Blob([typeof raw === 'string' ? raw : JSON.stringify(raw)], { type: contentType });
+            var a = document.createElement('a');
+            a.href = window.URL.createObjectURL(blob);
+            a.download = 'firewall_rules_export_' + (Date.now() / 1000 | 0) + '.' + ext;
+            a.click();
+            window.URL.revokeObjectURL(a.href);
+            $scope.actionFailed = true;
+            $scope.actionSuccess = false;
+        }
+
+        function exportError() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = "Could not connect to server. Please refresh this page.";
+        }
+    }
+
+    $scope.importRules = function () {
+        $scope.showImportFormatModal = true;
+        $scope.importRulesFormat = $scope.importRulesFormat || 'json';
+    };
+
+    $scope.closeImportFormatModal = function () {
+        $scope.showImportFormatModal = false;
+    };
+
+    $scope.confirmImportRules = function () {
+        $scope.showImportFormatModal = false;
+        var format = $scope.importRulesFormat || 'json';
+        var accept = format === 'excel' ? '.csv' : '.json';
+        var input = document.createElement('input');
+        input.type = 'file';
+        input.accept = accept;
+        input.style.display = 'none';
+        input.onchange = function(event) {
+            var file = event.target.files[0];
+            if (file) {
+                if (format === 'json') {
+                    var reader = new FileReader();
+                    reader.onload = function(e) {
+                        try {
+                            var importData = JSON.parse(e.target.result);
+                            if (!importData.rules || !Array.isArray(importData.rules)) {
+                                $scope.$apply(function() {
+                                    $scope.actionFailed = false;
+                                    $scope.actionSuccess = true;
+                                    $scope.errorMessage = "Invalid import file format. Please select a valid firewall rules export file.";
+                                });
+                                return;
+                            }
+                            uploadImportFile(file);
+                        } catch (err) {
+                            $scope.$apply(function() {
+                                $scope.actionFailed = false;
+                                $scope.actionSuccess = true;
+                                $scope.errorMessage = "Invalid JSON file. Please select a valid firewall rules export file.";
+                            });
+                        }
+                    };
+                    reader.readAsText(file);
+                } else {
+                    uploadImportFile(file);
+                }
+            }
+        };
+        document.body.appendChild(input);
+        input.click();
+        document.body.removeChild(input);
+    };
+
+    function uploadImportFile(file) {
+        $scope.rulesLoading = true;
+        $scope.actionFailed = true;
+        $scope.actionSuccess = true;
+
+        var formData = new FormData();
+        formData.append('import_file', file);
+
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken'),
+                'Content-Type': undefined
+            },
+            transformRequest: angular.identity
+        };
+
+        $http.post("/firewall/importFirewallRules", formData, config).then(importSuccess, importError);
+
+        function importSuccess(response) {
+            $scope.rulesLoading = false;
+            var res = response.data;
+            if (typeof res === 'string') {
+                try { res = JSON.parse(res); } catch (e) { res = {}; }
+            }
+            if (res && res.importStatus === 1) {
+                $scope.actionFailed = true;
+                $scope.actionSuccess = false;
+                populateCurrentRecords();
+                var summary = "Import completed successfully!\nImported: " + (res.imported_count || 0) + " rules\nSkipped: " + (res.skipped_count || 0) + " rules\nErrors: " + (res.error_count || 0) + " rules";
+                if (res.errors && res.errors.length > 0) {
+                    summary += "\n\nErrors:\n" + res.errors.join("\n");
+                }
+                alert(summary);
+            } else {
+                $scope.actionFailed = false;
+                $scope.actionSuccess = true;
+                $scope.errorMessage = (res && res.error_message) ? res.error_message : "Import failed.";
+            }
+        }
+
+        function importError() {
+            $scope.rulesLoading = false;
+            $scope.actionFailed = false;
+            $scope.actionSuccess = true;
+            $scope.errorMessage = "Could not connect to server. Please refresh this page.";
+        }
+    }
+
+    $scope.populateCurrentRecords = populateCurrentRecords;
 
 });
+
 
 /* Java script code to ADD Firewall Rules */
 
@@ -680,14 +1962,14 @@ app.controller('secureSSHCTRL', function ($scope, $http) {
 
     }
 
-    $scope.deleteKey = function (keyId) {
+    $scope.deleteKey = function (key) {
 
         $scope.secureSSHLoading = false;
 
         url = "/firewall/deleteSSHKey";
 
         var data = {
-            key: keyId,
+            key: key,
         };
 
         var config = {
@@ -1224,8 +2506,6 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
 
     var owaspInstalled = false;
     var comodoInstalled = false;
-    var counterOWASP = 0;
-    var counterComodo = 0;
     var updatingOWASPStatus = false;
     var updatingComodoStatus = false;
 
@@ -1234,46 +2514,34 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
 
         // Prevent triggering installation when status check updates the toggle
         if (updatingOWASPStatus) {
-            counterOWASP = counterOWASP + 1;  // Still increment counter
             return;
         }
 
         owaspInstalled = $(this).prop('checked');
         $scope.ruleFiles = true;
 
-        if (counterOWASP !== 0) {
-            if (owaspInstalled === true) {
-                installModSecRulesPack('installOWASP');
-            } else {
-                installModSecRulesPack('disableOWASP')
-            }
+        if (owaspInstalled === true) {
+            installModSecRulesPack('installOWASP');
+        } else {
+            installModSecRulesPack('disableOWASP');
         }
-
-        counterOWASP = counterOWASP + 1;
     });
 
     $('#comodoInstalled').change(function () {
 
         // Prevent triggering installation when status check updates the toggle
         if (updatingComodoStatus) {
-            counterComodo = counterComodo + 1;  // Still increment counter
             return;
         }
 
         $scope.ruleFiles = true;
         comodoInstalled = $(this).prop('checked');
 
-        if (counterComodo !== 0) {
-
-            if (comodoInstalled === true) {
-                installModSecRulesPack('installComodo');
-            } else {
-                installModSecRulesPack('disableComodo')
-            }
+        if (comodoInstalled === true) {
+            installModSecRulesPack('installComodo');
+        } else {
+            installModSecRulesPack('disableComodo');
         }
-
-        counterComodo = counterComodo + 1;
-
     });
 
 
@@ -1315,29 +2583,37 @@ app.controller('modSecRulesPack', function ($scope, $http, $timeout, $window) {
                     if (response.data.owaspInstalled === 1) {
                         $('#owaspInstalled').prop('checked', true);
                         $scope.owaspDisable = false;
+                        owaspInstalled = true;
                     } else {
                         $('#owaspInstalled').prop('checked', false);
                         $scope.owaspDisable = true;
+                        owaspInstalled = false;
                     }
                     if (response.data.comodoInstalled === 1) {
                         $('#comodoInstalled').prop('checked', true);
                         $scope.comodoDisable = false;
+                        comodoInstalled = true;
                     } else {
                         $('#comodoInstalled').prop('checked', false);
                         $scope.comodoDisable = true;
+                        comodoInstalled = false;
                     }
 
                 } else {
 
                     if (response.data.owaspInstalled === 1) {
                         $scope.owaspDisable = false;
+                        owaspInstalled = true;
                     } else {
                         $scope.owaspDisable = true;
+                        owaspInstalled = false;
                     }
                     if (response.data.comodoInstalled === 1) {
                         $scope.comodoDisable = false;
+                        comodoInstalled = true;
                     } else {
                         $scope.comodoDisable = true;
+                        comodoInstalled = false;
                     }
                 }
 
@@ -1738,16 +3014,16 @@ app.controller('csf', function ($scope, $http, $timeout, $window) {
     $scope.activateTab = function (newMain, newChild) {
         // Remove active class from all tabs
         $('.tab-button').removeClass('active');
-
+        
         // Add active class to clicked tab
         $('#' + newMain).addClass('active');
-
+        
         // Hide all tab contents
         $('.tab-content').removeClass('active');
-
+        
         // Show selected tab content
         $('#' + newChild).addClass('active');
-
+        
         currentMain = newMain;
         currentChild = newChild;
     };
@@ -2433,3 +3709,27 @@ app.controller('litespeed_ent_conf', function ($scope, $http, $timeout, $window)
     }
 
 });
+
+(function() {
+    // Do not capture tab clicks – let Angular ng-click run setFirewallTab() so data loads.
+    // Only sync tab from hash on load and hashchange (back/forward) via __firewallLoadTab.
+    function syncFirewallTabFromHash() {
+        var nav = document.getElementById('firewall-tab-nav');
+        if (!nav) return;
+        var h = (window.location.hash || '').replace(/^#/, '').toLowerCase();
+        var tab = 'rules';
+        if (h === 'banned-ips' || h === 'banned') tab = 'banned';
+        else if (h === 'trusted-ips' || h === 'ssh-whitelist') tab = 'trusted';
+        if (window.__firewallLoadTab) {
+            try { window.__firewallLoadTab(tab); } catch (e) {}
+        }
+    }
+
+    /* Initial sync only — hashchange is handled by Angular syncTabFromHash in firewallController
+       (multiple listeners were racing and could reset #trusted-ips to #rules). */
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', syncFirewallTabFromHash);
+    } else {
+        syncFirewallTabFromHash();
+    }
+})();

--- a/firewall/test_banned_ips.py
+++ b/firewall/test_banned_ips.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import os, sys, unittest
+sys.path.insert(0, '/usr/local/CyberCP')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CyberCP.settings')
+import django
+django.setup()
+
+class BannedIPsTests(unittest.TestCase):
+    def test_rule_order_module(self):
+        from firewall import ruleOrder
+        self.assertTrue(callable(ruleOrder.next_sort_order))
+
+    def test_bannedip_model(self):
+        from firewall.models import BannedIPs
+        self.assertTrue(hasattr(BannedIPs, 'ip_address'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/firewall/urls.py
+++ b/firewall/urls.py
@@ -3,10 +3,16 @@ from . import views
 
 urlpatterns = [
     path('securityHome', views.securityHome, name='securityHome'),
-    path('', views.firewallHome, name='firewallHome'),
+    path('firewall-rules/', views.firewallHome, name='firewallRules'),
+    path('firewall-rules', views.firewallHome, name='firewallRulesNoSlash'),
+    path('banned-ips/', views.firewallHome, name='firewallBannedIPs'),
+    path('banned-ips', views.firewallHome, name='firewallBannedIPsNoSlash'),
+    path('', views.firewallHome, name='firewallHome'),  # /firewall/ also serves the page so 404 is avoided
     path('getCurrentRules', views.getCurrentRules, name='getCurrentRules'),
     path('addRule', views.addRule, name='addRule'),
+    path('modifyRule', views.modifyRule, name='modifyRule'),
     path('deleteRule', views.deleteRule, name='deleteRule'),
+    path('reorderRules', views.reorderRules, name='reorderRules'),
 
     path('reloadFirewall', views.reloadFirewall, name='reloadFirewall'),
     path('stopFirewall', views.stopFirewall, name='stopFirewall'),
@@ -32,6 +38,15 @@ urlpatterns = [
     path('modSecRulesPacks', views.modSecRulesPacks, name='modSecRulesPacks'),
     path('getOWASPAndComodoStatus', views.getOWASPAndComodoStatus, name='getOWASPAndComodoStatus'),
     path('installModSecRulesPack', views.installModSecRulesPack, name='installModSecRulesPack'),
+    
+    # Banned IPs
+    path('getBannedIPs', views.getBannedIPs, name='getBannedIPs'),
+    path('addBannedIP', views.addBannedIP, name='addBannedIP'),
+    path('modifyBannedIP', views.modifyBannedIP, name='modifyBannedIP'),
+    path('removeBannedIP', views.removeBannedIP, name='removeBannedIP'),
+    path('deleteBannedIP', views.deleteBannedIP, name='deleteBannedIP'),
+    path('exportBannedIPs', views.exportBannedIPs, name='exportBannedIPs'),
+    path('importBannedIPs', views.importBannedIPs, name='importBannedIPs'),
     path('getRulesFiles', views.getRulesFiles, name='getRulesFiles'),
     path('enableDisableRuleFile', views.enableDisableRuleFile, name='enableDisableRuleFile'),
 
@@ -57,4 +72,8 @@ urlpatterns = [
     path('litespeed_ent_conf', views.litespeed_ent_conf, name='litespeed_ent_conf'),
     path('fetchlitespeed_conf', views.fetchlitespeed_conf, name='fetchlitespeed_conf'),
     path('saveLitespeed_conf', views.saveLitespeed_conf, name='saveLitespeed_conf'),
+    
+    # Firewall Export/Import
+    path('exportFirewallRules', views.exportFirewallRules, name='exportFirewallRules'),
+    path('importFirewallRules', views.importFirewallRules, name='importFirewallRules'),
 ]

--- a/firewall/views.py
+++ b/firewall/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import redirect
+from django.http import HttpResponse
 import json
 from loginSystem.views import loadLoginPage
 from plogical.processUtilities import ProcessUtilities
@@ -15,6 +16,16 @@ def securityHome(request):
         fm = FirewallManager()
         return fm.securityHome(request, userID)
     except KeyError:
+        return redirect(loadLoginPage)
+
+
+def firewallRedirect(request):
+    """Redirect /firewall/ to /firewall/firewall-rules/ so the default tab has a clear URL."""
+    try:
+        if request.session.get('userID'):
+            return redirect('/firewall/firewall-rules/')
+        return redirect(loadLoginPage)
+    except Exception:
         return redirect(loadLoginPage)
 
 
@@ -41,7 +52,14 @@ def getCurrentRules(request):
     try:
         userID = request.session['userID']
         fm = FirewallManager()
-        return fm.getCurrentRules(userID)
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            data = json.loads(body) if body and body.strip() else {}
+        except (json.JSONDecodeError, Exception):
+            data = {}
+        return fm.getCurrentRules(userID, data)
     except KeyError:
         return redirect(loadLoginPage)
 
@@ -66,6 +84,15 @@ def addRule(request):
         return redirect(loadLoginPage)
 
 
+def modifyRule(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        return fm.modifyRule(userID, json.loads(request.body))
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
 def deleteRule(request):
     try:
         userID = request.session['userID']
@@ -82,6 +109,22 @@ def deleteRule(request):
             return result
 
         return coreResult
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
+def reorderRules(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            data = json.loads(body) if body and body.strip() else {}
+        except (json.JSONDecodeError, Exception):
+            data = {}
+        return fm.reorderRules(userID, data)
     except KeyError:
         return redirect(loadLoginPage)
 
@@ -646,5 +689,185 @@ def saveLitespeed_conf(request):
         userID = request.session['userID']
         fm = FirewallManager()
         return fm.saveLitespeed_conf(userID, json.loads(request.body))
+    except KeyError:
+        return redirect(loadLoginPage)
+
+# Banned IPs Views
+def getBannedIPs(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        data = {}
+        if request.method == 'POST':
+            try:
+                body = request.body
+                if isinstance(body, bytes):
+                    body = body.decode('utf-8')
+                data = json.loads(body) if body and body.strip() else {}
+            except (json.JSONDecodeError, Exception):
+                pass
+        # GET also supported (no body); pagination uses defaults
+        result = fm.getBannedIPs(userID, data)
+        # Ensure we return JSON (FirewallManager may return HttpResponse)
+        return result
+    except KeyError:
+        final_dic = {'status': 0, 'error_message': 'Session expired. Please log in again.', 'bannedIPs': [], 'total_count': 0}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=403)
+
+def addBannedIP(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            request_data = json.loads(body) if body and body.strip() else {}
+        except json.JSONDecodeError as e:
+            final_dic = {'status': 0, 'error_message': 'Invalid JSON in request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        except Exception as e:
+            final_dic = {'status': 0, 'error_message': 'Error parsing request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        result = fm.addBannedIP(userID, request_data)
+        return result
+    except KeyError:
+        final_dic = {'status': 0, 'error_message': 'Session expired. Please refresh the page and try again.'}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=403)
+    except Exception as e:
+        import traceback
+        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as _log
+        error_trace = traceback.format_exc()
+        _log.writeToFile('Error in addBannedIP view: %s\n%s' % (str(e), error_trace))
+        final_dic = {'status': 0, 'error_message': 'Server error: %s' % str(e)}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=500)
+
+def modifyBannedIP(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            request_data = json.loads(body) if body and body.strip() else {}
+        except json.JSONDecodeError as e:
+            final_dic = {'status': 0, 'error_message': 'Invalid JSON in request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        except Exception as e:
+            final_dic = {'status': 0, 'error_message': 'Error parsing request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        return fm.modifyBannedIP(userID, request_data)
+    except KeyError:
+        final_dic = {'status': 0, 'error_message': 'Session expired. Please refresh the page and try again.'}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=403)
+    except Exception as e:
+        import traceback
+        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as _log
+        error_trace = traceback.format_exc()
+        _log.writeToFile('Error in modifyBannedIP view: %s\n%s' % (str(e), error_trace))
+        final_dic = {'status': 0, 'error_message': 'Server error: %s' % str(e)}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=500)
+
+def removeBannedIP(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            request_data = json.loads(body) if body and body.strip() else {}
+        except json.JSONDecodeError as e:
+            final_dic = {'status': 0, 'error_message': 'Invalid JSON in request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        except Exception as e:
+            final_dic = {'status': 0, 'error_message': 'Error parsing request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        return fm.removeBannedIP(userID, request_data)
+    except KeyError:
+        final_dic = {'status': 0, 'error_message': 'Session expired. Please refresh the page and try again.'}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=403)
+    except Exception as e:
+        import traceback
+        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as _log
+        error_trace = traceback.format_exc()
+        _log.writeToFile('Error in removeBannedIP view: %s\n%s' % (str(e), error_trace))
+        final_dic = {'status': 0, 'error_message': 'Server error: %s' % str(e)}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=500)
+
+def deleteBannedIP(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        try:
+            body = request.body
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            request_data = json.loads(body) if body and body.strip() else {}
+        except json.JSONDecodeError as e:
+            final_dic = {'status': 0, 'error_message': 'Invalid JSON in request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        except Exception as e:
+            final_dic = {'status': 0, 'error_message': 'Error parsing request: %s' % str(e)}
+            return HttpResponse(json.dumps(final_dic), content_type='application/json', status=400)
+        return fm.deleteBannedIP(userID, request_data)
+    except KeyError:
+        final_dic = {'status': 0, 'error_message': 'Session expired. Please refresh the page and try again.'}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=403)
+    except Exception as e:
+        import traceback
+        from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as _log
+        error_trace = traceback.format_exc()
+        _log.writeToFile('Error in deleteBannedIP view: %s\n%s' % (str(e), error_trace))
+        final_dic = {'status': 0, 'error_message': 'Server error: %s' % str(e)}
+        return HttpResponse(json.dumps(final_dic), content_type='application/json', status=500)
+
+
+def exportFirewallRules(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager(request)
+        return fm.exportFirewallRules(userID)
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
+def importFirewallRules(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager(request)
+        
+        # Handle file upload
+        if request.method == 'POST' and 'import_file' in request.FILES:
+            return fm.importFirewallRules(userID, None)
+        else:
+            # Handle JSON data
+            return fm.importFirewallRules(userID, json.loads(request.body))
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
+def exportBannedIPs(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        return fm.exportBannedIPs(userID)
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
+def importBannedIPs(request):
+    try:
+        userID = request.session['userID']
+        fm = FirewallManager()
+        fm.request = request  # Set request for file upload handling
+        
+        # Handle file upload
+        if request.method == 'POST' and 'import_file' in request.FILES:
+            return fm.importBannedIPs(userID, None)
+        else:
+            # Handle JSON data
+            return fm.importBannedIPs(userID, json.loads(request.body))
     except KeyError:
         return redirect(loadLoginPage)

--- a/install/postgresql_stack.md
+++ b/install/postgresql_stack.md
@@ -1,0 +1,5 @@
+# PostgreSQL stack (install reference)
+
+See `/usr/local/CyberCP/to-do/POSTGRESQL-STACK.md` on the server, or `to-do/POSTGRESQL-STACK.md` in this repository.
+
+Optional addon: `--postgresql-stack` on `cyberpanel.sh`.

--- a/postgresql-stack/.gitignore
+++ b/postgresql-stack/.gitignore
@@ -1,0 +1,9 @@
+config.php
+logs/
+tmp/
+*.log
+*.bak*
+__pycache__/
+.DS_Store
+*.tmp
+*.swp

--- a/postgresql-stack/.htaccess
+++ b/postgresql-stack/.htaccess
@@ -1,0 +1,12 @@
+<Files "config.php">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<Files ".env*">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<FilesMatch "\.(log|sql|bak|backup|key|pem|crt|tmp|temp|cache)$">
+    Order Allow,Deny
+    Deny from all
+</FilesMatch>

--- a/postgresql-stack/config.php.example
+++ b/postgresql-stack/config.php.example
@@ -1,0 +1,29 @@
+<?php
+if (!defined('APP_INIT')) {
+    http_response_code(404);
+    header('Content-Type: text/html; charset=utf-8');
+    echo '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>';
+    exit;
+}
+
+$config = array(
+    'pg_version' => '17',
+    'pg_port' => 5432,
+    'pg_superuser' => 'postgres',
+    'pg_superuser_password' => 'CHANGE_ME_pg_superuser',
+    'pg_app_user' => 'pgstack_app',
+    'pg_app_password' => 'CHANGE_ME_pg_app',
+    'pg_cron_database' => 'postgres',
+    'pgadmin_email' => 'pgadmin@example.com',
+    'pgadmin_password' => 'CHANGE_ME_pgadmin',
+    'pgadmin_sso_token' => '',
+    'pgadmin_bind_host' => '127.0.0.1',
+    'pgadmin_bind_port' => 5050,
+    'pgadmin_domain' => 'pgadmin.example.com',
+    'master_domain' => 'example.com',
+    'cyberpanel_owner' => 'Admin',
+    'cyberpanel_php' => '8.3',
+    'with_pgagent' => false,
+    'install_tile' => true,
+    'installed_at' => '',
+);

--- a/postgresql-stack/install.sh
+++ b/postgresql-stack/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# PostgreSQL + pgAdmin stack installer for CyberPanel hosts.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+PG_VERSION="17"
+PGADMIN_DOMAIN="pgadmin.newstargeted.com"
+MASTER_DOMAIN="newstargeted.com"
+WITH_PGAGENT=0
+NO_TILE=0
+SKIP_VERIFY=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --domain DOMAIN       pgAdmin subdomain (default: pgadmin.newstargeted.com)
+  --master-domain DOM   CyberPanel master domain (default: newstargeted.com)
+  --pg-version VER      PostgreSQL major version (default: 17)
+  --with-pgagent        Install deprecated pgAgent (not recommended)
+  --no-tile             Skip CyberPanel Quick App tile injection
+  --skip-verify         Skip post-install verification
+  -h, --help            Show this help
+
+Re-run safely: existing config.php secrets are preserved.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --domain) PGADMIN_DOMAIN="$2"; shift 2 ;;
+        --master-domain) MASTER_DOMAIN="$2"; shift 2 ;;
+        --pg-version) PG_VERSION="$2"; shift 2 ;;
+        --with-pgagent) WITH_PGAGENT=1; shift ;;
+        --no-tile) NO_TILE=1; shift ;;
+        --skip-verify) SKIP_VERIFY=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+require_root
+require_almalinux
+ensure_dirs
+init_config_if_missing
+load_config
+
+update_config_value "pg_version" "${PG_VERSION}"
+update_config_value "pgadmin_domain" "${PGADMIN_DOMAIN}"
+update_config_value "master_domain" "${MASTER_DOMAIN}"
+update_config_value "with_pgagent" "$([[ "${WITH_PGAGENT}" -eq 1 ]] && echo true || echo false)"
+update_config_value "install_tile" "$([[ "${NO_TILE}" -eq 1 ]] && echo false || echo true)"
+
+log_info "Starting PostgreSQL stack install (PG ${PG_VERSION}, domain ${PGADMIN_DOMAIN})"
+
+MODULES=(
+    "10-postgresql.sh"
+    "20-pg_cron.sh"
+)
+if [[ "${WITH_PGAGENT}" -eq 1 ]]; then
+    MODULES+=("30-pgagent.sh")
+fi
+MODULES+=(
+    "40-pgadmin.sh"
+    "45-pgadmin-server.sh"
+    "47-pgadmin-patches.sh"
+    "50-subdomain-proxy.sh"
+    "55-sso.sh"
+)
+if [[ "${NO_TILE}" -eq 0 ]]; then
+    MODULES+=("60-tile.sh")
+fi
+if [[ "${SKIP_VERIFY}" -eq 0 ]]; then
+    MODULES+=("90-verify.sh")
+fi
+
+for mod in "${MODULES[@]}"; do
+    run_module "${mod}"
+done
+
+log_info "Install complete. pgAdmin URL: https://${PGADMIN_DOMAIN}/"
+log_info "Credentials are stored in ${CONFIG_PHP} (chmod 600). Do not expose this file."

--- a/postgresql-stack/lib/apply_pgadmin_patches.sh
+++ b/postgresql-stack/lib/apply_pgadmin_patches.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Apply postgresql-stack patches to the installed pgAdmin bundle.
+# Idempotent: safe to re-run after pgAdmin package upgrades.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+APP_BUNDLE="/usr/pgadmin4/web/pgadmin/static/js/generated/app.bundle.js"
+MARKER="pgstack-adhoc-lazy-api"
+SRC_JSX="/usr/pgadmin4/web/pgadmin/misc/workspaces/static/js/AdHocConnection.jsx"
+
+patch_app_bundle() {
+    if [[ ! -f "${APP_BUNDLE}" ]]; then
+        log_error "pgAdmin bundle not found: ${APP_BUNDLE}"
+        return 1
+    fi
+    if grep -q "${MARKER}" "${APP_BUNDLE}"; then
+        log_info "pgAdmin Query Tool patch already applied (${MARKER})."
+        return 0
+    fi
+
+    local tmp
+    tmp="$(mktemp)"
+    python3 - "${APP_BUNDLE}" "${tmp}" "${MARKER}" <<'PY'
+import sys
+
+src_path, dst_path, marker = sys.argv[1:4]
+data = open(src_path, encoding="utf-8").read()
+old_ctor = "this.dbs=[],this.api=(0,g.default)(),this.connectExistingServer"
+new_ctor = f"this.dbs=[],/*{marker}*/this.connectExistingServer"
+if old_ctor not in data:
+    raise SystemExit("ERROR: AdHocConnection constructor pattern not found in app.bundle.js")
+data = data.replace(old_ctor, new_ctor, 1)
+old_get = 'this.api.get((0,o.default)("sqleditor.get_new_connection_servers"))'
+new_get = '(0,g.default)().get((0,o.default)("sqleditor.get_new_connection_servers"))'
+if old_get not in data:
+    raise SystemExit("ERROR: get_new_connection_servers API call pattern not found")
+data = data.replace(old_get, new_get, 1)
+old_other = "this.api.get((0,o.default)(`sqleditor.${t}`,{sid:e,sgid:0}))"
+new_other = "(0,g.default)().get((0,o.default)(`sqleditor.${t}`,{sid:e,sgid:0}))"
+if old_other not in data:
+    raise SystemExit("ERROR: getOtherOptions API call pattern not found")
+data = data.replace(old_other, new_other, 1)
+open(dst_path, "w", encoding="utf-8").write(data)
+print("patched")
+PY
+    cp -a "${APP_BUNDLE}" "${APP_BUNDLE}.bak.pgstack"
+    mv "${tmp}" "${APP_BUNDLE}"
+    chmod 644 "${APP_BUNDLE}"
+    chown root:root "${APP_BUNDLE}" 2>/dev/null || true
+    log_info "Patched ${APP_BUNDLE} (backup: ${APP_BUNDLE}.bak.pgstack)."
+}
+
+patch_source_jsx() {
+    if [[ ! -f "${SRC_JSX}" ]]; then
+        log_warn "AdHocConnection.jsx not found; bundle patch only."
+        return 0
+    fi
+    if grep -q "${MARKER}" "${SRC_JSX}"; then
+        return 0
+    fi
+    python3 - "${SRC_JSX}" "${MARKER}" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "    this.api = getApiInstance();\n",
+    f"    /* {marker}: lazy API client in getServerList/getOtherOptions */\n",
+    1,
+)
+text = text.replace("this.api.get(", "getApiInstance().get(", 2)
+if marker not in text:
+    raise SystemExit("jsx patch failed")
+path.write_text(text, encoding="utf-8")
+print("jsx patched")
+PY
+    log_info "Patched ${SRC_JSX}."
+}
+
+patch_app_bundle
+patch_source_jsx
+log_info "pgAdmin patches applied."

--- a/postgresql-stack/lib/common.sh
+++ b/postgresql-stack/lib/common.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Shared helpers for postgresql-stack installer.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export STACK_ROOT
+
+LOG_FILE="${STACK_ROOT}/logs/install.log"
+CONFIG_PHP="${STACK_ROOT}/config.php"
+
+log() {
+    local level="$1"
+    shift
+    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] [${level}] $*"
+    echo "${msg}" | tee -a "${LOG_FILE}"
+}
+
+log_info()  { log "INFO" "$@"; }
+log_warn()  { log "WARN" "$@"; }
+log_error() { log "ERROR" "$@"; }
+
+require_root() {
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        log_error "This script must run as root."
+        exit 1
+    fi
+}
+
+require_almalinux() {
+    if [[ ! -f /etc/os-release ]]; then
+        log_error "Cannot detect OS."
+        exit 1
+    fi
+    # shellcheck source=/dev/null
+    source /etc/os-release
+    if [[ "${ID:-}" != "almalinux" && "${ID:-}" != "rhel" && "${ID:-}" != "rocky" ]]; then
+        log_warn "OS is ${ID:-unknown}; installer targets AlmaLinux/RHEL 9."
+    fi
+}
+
+retry() {
+    local max_attempts="${1:-5}"
+    local delay="${2:-5}"
+    shift 2
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+            log_error "Command failed after ${max_attempts} attempts: $*"
+            return 1
+        fi
+        log_warn "Attempt ${attempt}/${max_attempts} failed; retry in ${delay}s: $*"
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+    done
+}
+
+gen_secret() {
+    local len="${1:-32}"
+    python3 -c "import secrets,string; print(''.join(secrets.choice(string.ascii_letters+string.digits) for _ in range(${len})))"
+}
+
+ensure_dirs() {
+    mkdir -p "${STACK_ROOT}/logs" "${STACK_ROOT}/tmp" "${STACK_ROOT}/Test"
+    touch "${LOG_FILE}"
+    chmod 750 "${STACK_ROOT}/logs"
+}
+
+load_config() {
+    if [[ ! -f "${CONFIG_PHP}" ]]; then
+        log_error "Missing config.php at ${CONFIG_PHP}. Run install.sh first."
+        exit 1
+    fi
+}
+
+cfg_get() {
+    local key="$1"
+    php -r "
+        define('APP_INIT', true);
+        require '${CONFIG_PHP}';
+        if (!isset(\$config['${key}'])) { fwrite(STDERR, 'missing key'); exit(2); }
+        echo \$config['${key}'];
+    " 2>/dev/null
+}
+
+init_config_if_missing() {
+    if [[ -f "${CONFIG_PHP}" ]]; then
+        log_info "config.php exists; preserving secrets."
+        return 0
+    fi
+
+    local pg_pass pgadmin_pass pgadmin_email
+    pg_pass="$(gen_secret 24)"
+    pgadmin_pass="$(gen_secret 20)"
+    pgadmin_email="pgadmin@$(hostname -f 2>/dev/null || echo 'localhost')"
+
+    cat > "${CONFIG_PHP}" <<EOFPHP
+<?php
+if (!defined('APP_INIT')) {
+    http_response_code(404);
+    header('Content-Type: text/html; charset=utf-8');
+    echo '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>';
+    exit;
+}
+
+\$config = array(
+    'pg_version' => '17',
+    'pg_port' => 5432,
+    'pg_superuser' => 'postgres',
+    'pg_superuser_password' => '${pg_pass}',
+    'pg_app_user' => 'pgstack_app',
+    'pg_app_password' => '$(gen_secret 24)',
+    'pg_cron_database' => 'postgres',
+    'pgadmin_email' => '${pgadmin_email}',
+    'pgadmin_password' => '${pgadmin_pass}',
+    'pgadmin_bind_host' => '127.0.0.1',
+    'pgadmin_bind_port' => 5050,
+    'pgadmin_domain' => 'pgadmin.newstargeted.com',
+    'master_domain' => 'newstargeted.com',
+    'cyberpanel_owner' => 'Admin',
+    'cyberpanel_php' => '8.3',
+    'with_pgagent' => false,
+    'install_tile' => true,
+    'installed_at' => '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
+);
+EOFPHP
+    chmod 600 "${CONFIG_PHP}"
+    log_info "Generated config.php (secrets not logged)."
+}
+
+update_config_value() {
+    local key="$1"
+    local value="$2"
+    CONFIG_PHP="${CONFIG_PHP}" CFG_KEY="${key}" CFG_VALUE="${value}" php -r '
+        define("APP_INIT", true);
+        $path = getenv("CONFIG_PHP");
+        require $path;
+        $k = getenv("CFG_KEY");
+        $v = getenv("CFG_VALUE");
+        if ($v === "true") {
+            $v = true;
+        } elseif ($v === "false") {
+            $v = false;
+        } elseif (preg_match("/^[0-9]+$/", (string) $v)) {
+            $v = (int) $v;
+        }
+        $config[$k] = $v;
+        $body = "<?php\nif (!defined(\"APP_INIT\")) { http_response_code(404); exit; }\n\n\$config = " . var_export($config, true) . ";\n";
+        file_put_contents($path, $body);
+    '
+    chmod 600 "${CONFIG_PHP}"
+}
+
+restart_lsws() {
+    log_info "Restarting LiteSpeed (lsws)..."
+    if systemctl is-active --quiet lsws 2>/dev/null; then
+        systemctl restart lsws
+    elif [[ -x /usr/local/lsws/bin/lsctl ]]; then
+        /usr/local/lsws/bin/lsctl restart
+    else
+        service lsws restart
+    fi
+    sleep 2
+}
+
+pg_service_name() {
+    local ver
+    ver="$(cfg_get pg_version 2>/dev/null || echo '17')"
+    echo "postgresql-${ver}"
+}
+
+pg_bin_dir() {
+    local ver
+    ver="$(cfg_get pg_version 2>/dev/null || echo '17')"
+    if [[ -d "/usr/pgsql-${ver}/bin" ]]; then
+        echo "/usr/pgsql-${ver}/bin"
+    else
+        echo "/usr/bin"
+    fi
+}
+
+pg_data_dir() {
+    local ver
+    ver="$(cfg_get pg_version 2>/dev/null || echo '17')"
+    echo "/var/lib/pgsql/${ver}/data"
+}
+
+pg_conf_file() {
+    echo "$(pg_data_dir)/postgresql.conf"
+}
+
+run_module() {
+    local script="${STACK_ROOT}/modules/${1}"
+    if [[ ! -f "${script}" ]]; then
+        log_error "Missing module: ${script}"
+        exit 1
+    fi
+    log_info "Running module: $(basename "${script}")"
+    # shellcheck source=/dev/null
+    source "${STACK_ROOT}/lib/common.sh"
+    bash "${script}"
+}

--- a/postgresql-stack/lib/pgadmin_env.sh
+++ b/postgresql-stack/lib/pgadmin_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run pgAdmin setup.py via venv Python (avoid /usr/local package conflicts).
+pgadmin_python() {
+    local pgadmin_web="/usr/pgadmin4/web"
+    local pgadmin_py="/usr/pgadmin4/venv/bin/python3"
+    local args_json
+    args_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' -- "$@")"
+    (
+        cd "${pgadmin_web}"
+        ARGS_JSON="${args_json}" "${pgadmin_py}" -c "
+import json, os, runpy, sys
+sys.path = [p for p in sys.path if '/usr/local/' not in p]
+sys.argv = ['setup.py'] + json.loads(os.environ['ARGS_JSON'])
+runpy.run_path('setup.py', run_name='__main__')
+"
+    )
+}

--- a/postgresql-stack/lib/pgadmin_wsgi.py
+++ b/postgresql-stack/lib/pgadmin_wsgi.py
@@ -1,0 +1,331 @@
+"""Gunicorn entry for pgAdmin with /usr/local site-package filter.
+
+Also provides a small, self-contained Single-Sign-On (SSO) launcher mounted at
+``/sso``. The CyberPanel "Open pgAdmin" tile points at ``/sso/?key=<token>``.
+When the token matches the per-install secret, the launcher logs in to pgAdmin
+server-side using the randomly generated pgAdmin credentials and hands the
+browser an authenticated session cookie. The user never sees or types the
+username/password.
+
+The login is performed over the loopback HTTP interface (the same path a real
+browser would take), which yields a session that is valid across all gunicorn
+workers. In-process WSGI calls are intentionally avoided because the resulting
+session is only cached in the worker that created it.
+
+Security model:
+  * The launcher only acts when the request carries the correct per-install
+    token (constant-time compared). Without it the response is 403.
+  * pgAdmin keeps its normal login page as a fallback (defense in depth): a
+    direct visit without the token still requires the password.
+  * The secret file (token + credentials) is readable only by the pgAdmin
+    service user (apache), chmod 600.
+"""
+import http.client
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, "/usr/pgadmin4/web")
+sys.path = [p for p in sys.path if "/usr/local/" not in p]
+
+from pgAdmin4 import app  # noqa: E402
+
+
+def _install_pass_enc_key_hook():
+    """Store the login password in session so saved server passwords decrypt on any worker.
+
+    pgAdmin's internal login only sets keyManager in-process. With multiple
+    gunicorn workers that breaks saved-password connect. OAuth/Kerberos auth sets
+    session['pass_enc_key']; mirror that for password login (including SSO).
+    """
+    try:
+        import config
+        from flask import request, session
+        from flask_login.signals import user_logged_in
+
+        @user_logged_in.connect_via(app)
+        def _store_pass_enc_key(sender, user):
+            if not config.SERVER_MODE or config.MASTER_PASSWORD_REQUIRED:
+                return
+            pwd = request.form.get("password")
+            if pwd:
+                session["pass_enc_key"] = pwd
+                session.force_write = True
+    except Exception:
+        pass
+
+
+_install_pass_enc_key_hook()
+
+SECRET_FILE = os.environ.get("PGSTACK_SSO_SECRET", "/var/lib/pgadmin/.pgstack-sso.json")
+LOGIN_PAGE_PATH = "/login"
+LOGIN_API_PATH = "/authenticate/login"
+POST_LOGIN_PATH = "/browser/"
+UTILS_JS_PATH = "/browser/js/utils.js"
+CSRF_RE = re.compile(rb'"csrfToken":\s*"([^"]+)"')
+CSRF_UTILS_RE = re.compile(r"pgAdmin\['csrf_token'\]\s*=\s*'([^']+)'")
+CSRF_HEADER_RE = re.compile(r"pgAdmin\['csrf_token_header'\]\s*=\s*'([^']+)'")
+SESSION_COOKIE_RE = re.compile(r"(pga4_session=[^;]+)")
+HTTP_TIMEOUT = 15
+
+
+def _load_secret():
+    try:
+        with open(SECRET_FILE, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if data.get("token") and data.get("email") and data.get("password"):
+            return data
+    except Exception:
+        return None
+    return None
+
+
+def _const_eq(a, b):
+    try:
+        import hmac
+
+        return hmac.compare_digest(str(a), str(b))
+    except Exception:
+        return False
+
+
+def _backend(secret):
+    host = (secret or {}).get("backend_host") or "127.0.0.1"
+    port = int((secret or {}).get("backend_port") or 5050)
+    return host, port
+
+
+def _request(backend, method, path, host, headers=None, body=None):
+    """Perform a loopback HTTP request to the pgAdmin backend."""
+    conn = http.client.HTTPConnection(backend[0], backend[1], timeout=HTTP_TIMEOUT)
+    try:
+        req_headers = {"Host": host}
+        if headers:
+            req_headers.update(headers)
+        conn.request(method, path, body=body, headers=req_headers)
+        resp = conn.getresponse()
+        data = resp.read()
+        set_cookies = resp.getheader("Set-Cookie")
+        # getheader collapses duplicates; use get_all-like access via msg
+        try:
+            all_cookies = resp.msg.get_all("Set-Cookie") or []
+        except Exception:
+            all_cookies = [set_cookies] if set_cookies else []
+        return resp.status, all_cookies, resp.getheader("Location"), data
+    finally:
+        conn.close()
+
+
+def _session_cookie(set_cookies):
+    """Return (full_set_cookie_string, 'pga4_session=value') or (None, None)."""
+    for cookie in set_cookies or []:
+        if not cookie:
+            continue
+        m = SESSION_COOKIE_RE.search(cookie)
+        if m:
+            return cookie, m.group(1)
+    return None, None
+
+
+def _browser_referer(host):
+    scheme = "https"
+    hostname = (host or "localhost").split(":")[0]
+    return "{0}://{1}/browser/".format(scheme, hostname)
+
+
+def _fetch_browser_csrf(backend, host, session_kv, fwd):
+    """Load authenticated /browser/js/utils.js and parse CSRF token + header."""
+    headers = dict(fwd)
+    headers["Cookie"] = session_kv
+    status, _, _, body = _request(backend, "GET", UTILS_JS_PATH, host, headers=headers)
+    if status != 200:
+        return None, None
+    try:
+        text = body.decode("utf-8", errors="replace")
+    except Exception:
+        return None, None
+    csrf_m = CSRF_UTILS_RE.search(text)
+    hdr_m = CSRF_HEADER_RE.search(text)
+    if not csrf_m or not hdr_m:
+        return None, None
+    return csrf_m.group(1), hdr_m.group(1)
+
+
+def _connect_registered_server(backend, host, session_kv, fwd, secret):
+    """Pre-connect the stack-registered PostgreSQL server after SSO login."""
+    try:
+        gid = int(secret.get("server_gid") or 0)
+        sid = int(secret.get("server_sid") or 0)
+    except Exception:
+        return False
+    if gid <= 0 or sid <= 0:
+        return False
+
+    csrf, csrf_header = _fetch_browser_csrf(backend, host, session_kv, fwd)
+    if not csrf or not csrf_header:
+        return False
+
+    path = "/browser/server/connect/{0}/{1}".format(gid, sid)
+    post_headers = dict(fwd)
+    post_headers.update(
+        {
+            "Cookie": session_kv,
+            csrf_header: csrf,
+            "Referer": _browser_referer(host),
+            "Content-Type": "application/json",
+            "Content-Length": "2",
+        }
+    )
+    status, _, _, body = _request(
+        backend, "POST", path, host, headers=post_headers, body=b"{}"
+    )
+    if status != 200:
+        return False
+    try:
+        payload = json.loads(body.decode("utf-8", errors="replace") or "{}")
+    except Exception:
+        return False
+    return bool(payload.get("success"))
+
+
+def _redirect(start_response, location, set_cookie=None):
+    body = (
+        b"<!doctype html><html><head><meta charset='utf-8'>"
+        b"<title>Opening pgAdmin...</title></head><body>"
+        b"<p>Opening pgAdmin... If you are not redirected, "
+        b"<a href='" + location.encode("utf-8") + b"'>click here</a>.</p>"
+        b"</body></html>"
+    )
+    headers = [
+        ("Location", location),
+        ("Content-Type", "text/html; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+        ("Cache-Control", "no-store"),
+        ("Referrer-Policy", "no-referrer"),
+        ("X-Content-Type-Options", "nosniff"),
+    ]
+    if set_cookie:
+        headers.append(("Set-Cookie", set_cookie))
+    start_response("302 Found", headers)
+    return [body]
+
+
+def _forbidden(start_response):
+    body = b"403 Forbidden"
+    start_response(
+        "403 Forbidden",
+        [
+            ("Content-Type", "text/plain; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+            ("Cache-Control", "no-store"),
+            ("Referrer-Policy", "no-referrer"),
+        ],
+    )
+    return [body]
+
+
+def _parse_query_key(query_string):
+    try:
+        from urllib.parse import parse_qs
+
+        values = parse_qs(query_string or "")
+        key = values.get("key", [""])
+        return key[0] if key else ""
+    except Exception:
+        return ""
+
+
+def _forwarded_headers(environ):
+    """Headers that make the loopback login look like the real client.
+
+    pgAdmin's Paranoid extension binds the session to
+    sha256(X-Forwarded-For-first-IP + '|' + User-Agent). The loopback login must
+    present the same User-Agent and client IP that the browser will send on its
+    subsequent requests (via LiteSpeed), otherwise pgAdmin invalidates the
+    session and bounces the user back to the login page.
+    """
+    headers = {}
+    ua = environ.get("HTTP_USER_AGENT")
+    if ua:
+        headers["User-Agent"] = ua
+    xff = environ.get("HTTP_X_FORWARDED_FOR") or environ.get("REMOTE_ADDR")
+    if xff:
+        headers["X-Forwarded-For"] = xff
+    headers["X-Forwarded-Proto"] = environ.get("HTTP_X_FORWARDED_PROTO") or "https"
+    return headers
+
+
+def _perform_sso(environ, start_response):
+    secret = _load_secret()
+    host = environ.get("HTTP_HOST", "localhost")
+    provided = _parse_query_key(environ.get("QUERY_STRING", ""))
+
+    if not secret or not provided or not _const_eq(secret["token"], provided):
+        return _forbidden(start_response)
+
+    backend = _backend(secret)
+    fwd = _forwarded_headers(environ)
+    try:
+        # Step 1: fetch login page for CSRF token + initial session cookie.
+        get_headers = dict(fwd)
+        _, sc1, _, body1 = _request(backend, "GET", LOGIN_PAGE_PATH, host, headers=get_headers)
+        csrf_match = CSRF_RE.search(body1)
+        cookie_full, session_kv = _session_cookie(sc1)
+        if not csrf_match or not session_kv:
+            return _redirect(start_response, LOGIN_PAGE_PATH)
+        csrf = csrf_match.group(1).decode("utf-8")
+
+        # Step 2: authenticate with credentials.
+        from urllib.parse import urlencode
+
+        form = urlencode(
+            {
+                "email": secret["email"],
+                "password": secret["password"],
+                "csrf_token": csrf,
+            }
+        ).encode("utf-8")
+        post_headers = dict(fwd)
+        post_headers.update(
+            {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Cookie": session_kv,
+                "X-CSRFToken": csrf,
+                "Content-Length": str(len(form)),
+            }
+        )
+        status2, sc2, _, _ = _request(
+            backend,
+            "POST",
+            LOGIN_API_PATH,
+            host,
+            headers=post_headers,
+            body=form,
+        )
+        if status2 not in (200, 302):
+            return _redirect(start_response, LOGIN_PAGE_PATH)
+
+        auth_cookie, auth_kv = _session_cookie(sc2)
+        relay_cookie = auth_cookie or cookie_full
+        session_kv = auth_kv or session_kv
+        if session_kv:
+            _connect_registered_server(backend, host, session_kv, fwd, secret)
+        return _redirect(start_response, POST_LOGIN_PATH, set_cookie=relay_cookie)
+    except Exception:
+        # Never break access; fall back to the standard login page.
+        return _redirect(start_response, LOGIN_PAGE_PATH)
+
+
+class SSOMiddleware:
+    def __init__(self, wsgi_app):
+        self.wsgi_app = wsgi_app
+
+    def __call__(self, environ, start_response):
+        path = environ.get("PATH_INFO", "")
+        if path.rstrip("/") == "/sso":
+            return _perform_sso(environ, start_response)
+        return self.wsgi_app(environ, start_response)
+
+
+application = SSOMiddleware(app)

--- a/postgresql-stack/lib/register_pg_server.py
+++ b/postgresql-stack/lib/register_pg_server.py
@@ -1,0 +1,127 @@
+"""Register the local PostgreSQL server in pgAdmin for the stack admin user.
+
+The server password is encrypted with the pgAdmin login password (same key used
+after SSO login), so saved-password connect works without prompting.
+
+Environment variables (set by modules/45-pgadmin-server.sh):
+  PGADMIN_EMAIL, PGADMIN_PASSWORD, PG_SUPERUSER, PG_SUPERUSER_PASSWORD,
+  PG_HOST, PG_PORT, PG_MAINT_DB, PG_SERVER_NAME, PG_DISCOVERY_ID
+"""
+import os
+import sys
+
+sys.path.insert(0, "/usr/pgadmin4/web")
+sys.path = [p for p in sys.path if "/usr/local/" not in p]
+
+
+def _env(name, default=None):
+    value = os.environ.get(name, default)
+    if value is None or value == "":
+        raise RuntimeError("Missing required environment variable: {}".format(name))
+    return value
+
+
+def main():
+    email = _env("PGADMIN_EMAIL")
+    pgadmin_pass = _env("PGADMIN_PASSWORD")
+    pg_super_pass = _env("PG_SUPERUSER_PASSWORD")
+    pg_user = os.environ.get("PG_SUPERUSER", "postgres")
+    host = os.environ.get("PG_HOST", "127.0.0.1")
+    port = int(os.environ.get("PG_PORT", "5432"))
+    maint_db = os.environ.get("PG_MAINT_DB", "postgres")
+    server_name = os.environ.get("PG_SERVER_NAME", "PostgreSQL (localhost)")
+    discovery_id = os.environ.get("PG_DISCOVERY_ID", "POSTGRESQL_STACK/local")
+
+    import config
+    from pgadmin import create_app
+    from pgadmin.model import Server, ServerGroup, User, db
+    from pgadmin.utils.crypto import encrypt
+
+    app = create_app(config.APP_NAME + "-cli")
+    with app.app_context():
+        user_row = User.query.filter_by(username=email).first()
+        if user_row is None:
+            print("ERROR: pgAdmin user not found: {}".format(email))
+            return 1
+
+        group = ServerGroup.query.filter_by(user_id=user_row.id).order_by("id").first()
+        if group is None:
+            group = ServerGroup(name="Servers", user_id=user_row.id)
+            db.session.add(group)
+            db.session.commit()
+
+        server = Server.query.filter_by(
+            user_id=user_row.id, discovery_id=discovery_id
+        ).first()
+        if server is None:
+            server = Server.query.filter_by(
+                user_id=user_row.id, name=server_name
+            ).first()
+
+        enc_pwd = encrypt(pg_super_pass, pgadmin_pass)
+        conn_params = {"sslmode": "prefer", "connect_timeout": 10}
+
+        if server is None:
+            server = Server(
+                user_id=user_row.id,
+                servergroup_id=group.id,
+                name=server_name,
+                host=host,
+                port=port,
+                maintenance_db=maint_db,
+                username=pg_user,
+                password=enc_pwd,
+                save_password=1,
+                discovery_id=discovery_id,
+                use_ssh_tunnel=0,
+                tunnel_authentication=0,
+                tunnel_prompt_password=0,
+                shared=False,
+                kerberos_conn=False,
+                connection_params=conn_params,
+                comment="Managed by postgresql-stack installer",
+            )
+            db.session.add(server)
+            action = "registered"
+        else:
+            server.servergroup_id = group.id
+            server.name = server_name
+            server.host = host
+            server.port = port
+            server.maintenance_db = maint_db
+            server.username = pg_user
+            server.password = enc_pwd
+            server.save_password = 1
+            server.discovery_id = discovery_id
+            server.connection_params = conn_params
+            server.comment = "Managed by postgresql-stack installer"
+            action = "updated"
+
+        try:
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            print("ERROR: failed to save server: {}".format(exc))
+            return 1
+
+        print("OK: {} server '{}' for {}".format(action, server_name, email))
+
+        # Remove stale auto-discovered duplicates (from postgres-reg.ini on login).
+        dupes = Server.query.filter(
+            Server.user_id == user_row.id,
+            Server.name == server_name,
+            Server.discovery_id != discovery_id,
+        ).all()
+        for dup in dupes:
+            db.session.delete(dup)
+        if dupes:
+            db.session.commit()
+            print("OK: removed {} duplicate server row(s)".format(len(dupes)))
+
+        print("SERVER_GID={}".format(group.id))
+        print("SERVER_SID={}".format(server.id))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/postgresql-stack/lib/update_sso_server_ids.py
+++ b/postgresql-stack/lib/update_sso_server_ids.py
@@ -1,0 +1,36 @@
+"""Merge server_group/server ids into the pgAdmin SSO secret file."""
+import json
+import os
+import sys
+
+SECRET_FILE = os.environ.get("PGSTACK_SSO_SECRET", "/var/lib/pgadmin/.pgstack-sso.json")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: update_sso_server_ids.py <server_gid> <server_sid>", file=sys.stderr)
+        return 2
+    gid = int(sys.argv[1])
+    sid = int(sys.argv[2])
+    data = {}
+    try:
+        with open(SECRET_FILE, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        print("WARN: SSO secret file missing; run modules/55-sso.sh first.", file=sys.stderr)
+    except Exception as exc:
+        print("WARN: could not read SSO secret: {}".format(exc), file=sys.stderr)
+    data["server_gid"] = gid
+    data["server_sid"] = sid
+    try:
+        with open(SECRET_FILE, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+    except Exception as exc:
+        print("ERROR: failed to write SSO secret: {}".format(exc), file=sys.stderr)
+        return 1
+    print("OK: SSO secret updated server_gid={} server_sid={}".format(gid, sid))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/postgresql-stack/modules/10-postgresql.sh
+++ b/postgresql-stack/modules/10-postgresql.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Install PostgreSQL server from PGDG (AlmaLinux 9).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_VER="$(cfg_get pg_version)"
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+PG_DATA="$(pg_data_dir)"
+PG_PASS="$(cfg_get pg_superuser_password)"
+APP_USER="$(cfg_get pg_app_user)"
+APP_PASS="$(cfg_get pg_app_password)"
+
+install_pgdg_repo() {
+    if rpm -q pgdg-redhat-repo >/dev/null 2>&1; then
+        log_info "PGDG repo already installed."
+        return 0
+    fi
+    log_info "Installing PGDG repository..."
+    retry 3 5 dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E '%{rhel}')-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm"
+    dnf -qy module disable postgresql 2>/dev/null || true
+}
+
+install_packages() {
+    log_info "Installing PostgreSQL ${PG_VER} packages..."
+    retry 3 10 dnf install -y \
+        "postgresql${PG_VER}-server" \
+        "postgresql${PG_VER}-contrib" \
+        "postgresql${PG_VER}"
+    # system_stats powers the pgAdmin Dashboard > System tab.
+    if ! dnf install -y "system_stats_${PG_VER}" 2>/dev/null; then
+        log_warn "system_stats_${PG_VER} package not available; pgAdmin System tab will be limited."
+    fi
+}
+
+create_system_stats_extension() {
+    # Created in the maintenance DB so pgAdmin's Dashboard > System tab works.
+    if ! rpm -q "system_stats_${PG_VER}" >/dev/null 2>&1; then
+        return 0
+    fi
+    log_info "Creating system_stats extension in 'postgres' database..."
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -d postgres -c \
+        "CREATE EXTENSION IF NOT EXISTS system_stats;" || \
+        log_warn "Could not create system_stats extension."
+}
+
+init_database() {
+    if [[ -f "${PG_DATA}/PG_VERSION" ]]; then
+        log_info "PostgreSQL data directory already initialized."
+        return 0
+    fi
+    log_info "Initializing PostgreSQL cluster..."
+    "${PG_BIN}/postgresql-${PG_VER}-setup" initdb
+}
+
+configure_postgresql() {
+    local conf="${PG_DATA}/postgresql.conf"
+    local hba="${PG_DATA}/pg_hba.conf"
+
+    log_info "Configuring PostgreSQL (localhost only)..."
+    if grep -q "^listen_addresses" "${conf}"; then
+        sed -i "s/^#*listen_addresses.*/listen_addresses = 'localhost'/" "${conf}"
+    else
+        echo "listen_addresses = 'localhost'" >> "${conf}"
+    fi
+
+    if ! grep -q "^port" "${conf}"; then
+        echo "port = $(cfg_get pg_port)" >> "${conf}"
+    fi
+
+    # Local peer for postgres OS user; scram for TCP localhost
+    if ! grep -q "postgresql-stack" "${hba}"; then
+        cat >> "${hba}" <<'EOF'
+
+# postgresql-stack
+local   all             postgres                                peer
+host    all             all             127.0.0.1/32            scram-sha-256
+host    all             all             ::1/128                 scram-sha-256
+EOF
+    fi
+}
+
+set_postgres_password() {
+    log_info "Setting postgres superuser password..."
+    systemctl enable "${PG_SVC}"
+    systemctl start "${PG_SVC}"
+    retry 5 3 systemctl is-active --quiet "${PG_SVC}"
+
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -c \
+        "ALTER USER postgres WITH PASSWORD '$(echo "${PG_PASS}" | sed "s/'/''/g")';"
+}
+
+run_bootstrap_sql() {
+    local sql_file="/tmp/postgresql-stack-bootstrap-$$.sql"
+    sed -e "s/__PG_APP_USER__/${APP_USER}/g" \
+        -e "s/__PG_APP_PASSWORD__/$(echo "${APP_PASS}" | sed "s/'/''/g")/g" \
+        "${STACK_ROOT}/sql/bootstrap.sql" > "${sql_file}"
+    chmod 644 "${sql_file}"
+
+    log_info "Running bootstrap SQL..."
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -f "${sql_file}"
+    rm -f "${sql_file}"
+}
+
+install_pgdg_repo
+install_packages
+init_database
+configure_postgresql
+systemctl enable "${PG_SVC}"
+systemctl restart "${PG_SVC}"
+retry 5 3 systemctl is-active --quiet "${PG_SVC}"
+set_postgres_password
+run_bootstrap_sql
+create_system_stats_extension
+
+log_info "PostgreSQL ${PG_VER} is running (localhost only)."

--- a/postgresql-stack/modules/20-pg_cron.sh
+++ b/postgresql-stack/modules/20-pg_cron.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Install and configure pg_cron extension.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_VER="$(cfg_get pg_version)"
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+PG_DATA="$(pg_data_dir)"
+CRON_DB="$(cfg_get pg_cron_database)"
+CONF="$(pg_conf_file)"
+
+install_pg_cron_package() {
+    log_info "Installing pg_cron for PostgreSQL ${PG_VER}..."
+    retry 3 10 dnf install -y "pg_cron_${PG_VER}"
+}
+
+configure_shared_preload() {
+    log_info "Configuring shared_preload_libraries for pg_cron..."
+    if grep -qE "^shared_preload_libraries\s*=" "${CONF}"; then
+        if grep -q "pg_cron" "${CONF}"; then
+            log_info "pg_cron already in shared_preload_libraries."
+        else
+            sed -i -E "s/^shared_preload_libraries\s*=\s*'([^']*)'/shared_preload_libraries = '\1,pg_cron'/" "${CONF}"
+        fi
+    elif grep -qE "^#shared_preload_libraries\s*=" "${CONF}"; then
+        sed -i -E "s/^#shared_preload_libraries\s*=.*/shared_preload_libraries = 'pg_cron'/" "${CONF}"
+    else
+        echo "shared_preload_libraries = 'pg_cron'" >> "${CONF}"
+    fi
+
+    if grep -q "^cron.database_name" "${CONF}"; then
+        sed -i "s/^#*cron.database_name.*/cron.database_name = '${CRON_DB}'/" "${CONF}"
+    else
+        echo "cron.database_name = '${CRON_DB}'" >> "${CONF}"
+    fi
+}
+
+create_extension() {
+    log_info "Creating pg_cron extension in database ${CRON_DB}..."
+    systemctl restart "${PG_SVC}"
+    retry 8 5 systemctl is-active --quiet "${PG_SVC}"
+    sleep 2
+
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -d "${CRON_DB}" -c \
+        "CREATE EXTENSION IF NOT EXISTS pg_cron;"
+}
+
+install_pg_cron_package
+configure_shared_preload
+create_extension
+
+log_info "pg_cron installed and active."

--- a/postgresql-stack/modules/30-pgagent.sh
+++ b/postgresql-stack/modules/30-pgagent.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Optional pgAgent install (deprecated upstream; use pg_cron instead).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_VER="$(cfg_get pg_version)"
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+CRON_DB="$(cfg_get pg_cron_database)"
+
+log_warn "pgAgent is deprecated by the pgAdmin team. Prefer pg_cron (already installed)."
+log_warn "See: https://www.pgadmin.org/download/pgagent-source-code/"
+
+retry 3 10 dnf install -y "pgagent_${PG_VER}" 2>/dev/null || {
+    log_warn "pgagent_${PG_VER} package not found in PGDG; trying pgagent..."
+    retry 3 10 dnf install -y pgagent || {
+        log_error "pgAgent package unavailable. Skipping."
+        exit 0
+    }
+}
+
+if [[ -f /usr/share/pgagent/pgagent.sql ]]; then
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -d "${CRON_DB}" -f /usr/share/pgagent/pgagent.sql 2>/dev/null || \
+        log_warn "pgAgent SQL may already be applied."
+fi
+
+if systemctl list-unit-files | grep -q pgagent; then
+    systemctl enable pgagent 2>/dev/null || true
+    systemctl start pgagent 2>/dev/null || log_warn "pgagent service failed to start; configure manually."
+fi
+
+log_info "pgAgent install step finished (optional component)."

--- a/postgresql-stack/modules/40-pgadmin.sh
+++ b/postgresql-stack/modules/40-pgadmin.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Install pgAdmin4 web and run via gunicorn (systemd).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_EMAIL="$(cfg_get pgadmin_email)"
+PGADMIN_PASS="$(cfg_get pgadmin_password)"
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+PGADMIN_WEB="/usr/pgadmin4/web"
+PGADMIN_VENV="/usr/pgadmin4/venv/bin"
+LOCAL_CFG="${PGADMIN_WEB}/config_local.py"
+# shellcheck source=../lib/pgadmin_env.sh
+source "${STACK_ROOT}/lib/pgadmin_env.sh"
+
+install_pgadmin_repo() {
+    if rpm -q pgadmin4-web >/dev/null 2>&1; then
+        log_info "pgadmin4-web already installed."
+        return 0
+    fi
+    log_info "Installing pgAdmin 4 repository and packages..."
+    if ! rpm -q pgadmin4-redhat-repo >/dev/null 2>&1; then
+        retry 3 5 dnf install -y \
+            "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/yum/pgadmin4-redhat-repo-2-1.noarch.rpm"
+    fi
+    retry 3 10 dnf install -y pgadmin4-web python3-gunicorn
+}
+
+configure_pgadmin_local() {
+    log_info "Writing pgAdmin local config (${LOCAL_CFG})..."
+    cat > "${LOCAL_CFG}" <<EOF
+# Managed by postgresql-stack installer
+DEFAULT_SERVER = '0.0.0.0'
+MASTER_PASSWORD_REQUIRED = False
+WTF_CSRF_ENABLED = True
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+LOG_FILE = '/var/log/pgadmin/pgadmin.log'
+SERVER_MODE = True
+# Disabled so the one-click SSO launcher session is not invalidated when the
+# login (performed server-side over loopback) and the browser present a
+# different IP/User-Agent. Cookies remain Secure + HttpOnly + SameSite=Lax.
+ENHANCED_COOKIE_PROTECTION = False
+ALLOW_SPECIAL_EMAIL_DOMAINS = []
+ALLOW_SPECIAL_EMAIL_ADDRESSES = ['${PGADMIN_EMAIL}']
+EOF
+    chmod 640 "${LOCAL_CFG}"
+    chown root:apache "${LOCAL_CFG}" 2>/dev/null || chmod 644 "${LOCAL_CFG}"
+    mkdir -p /var/log/pgadmin4 /var/log/pgadmin /var/lib/pgadmin
+    chown -R apache:apache /var/log/pgadmin4 /var/log/pgadmin /var/lib/pgadmin 2>/dev/null || true
+    chmod 750 /var/log/pgadmin4 /var/log/pgadmin /var/lib/pgadmin
+}
+
+setup_pgadmin_user() {
+    log_info "Initializing pgAdmin database and admin user..."
+    mkdir -p /var/log/pgadmin /var/lib/pgadmin
+    chown apache:apache /var/log/pgadmin /var/lib/pgadmin 2>/dev/null || true
+    chmod 750 /var/log/pgadmin /var/lib/pgadmin
+
+    export PGADMIN_SETUP_EMAIL="${PGADMIN_EMAIL}"
+    export PGADMIN_SETUP_PASSWORD="${PGADMIN_PASS}"
+
+    local db_ok=0
+    if [[ -f /var/lib/pgadmin/pgadmin4.db ]]; then
+        if pgadmin_python get-users --json >/dev/null 2>&1; then
+            db_ok=1
+            log_info "pgAdmin SQLite DB already exists and is valid."
+        else
+            log_warn "pgAdmin DB invalid; backing up and reinitializing..."
+            mv /var/lib/pgadmin/pgadmin4.db "/var/lib/pgadmin/pgadmin4.db.bak.$(date +%Y%m%d%H%M%S)"
+        fi
+    fi
+
+    if [[ "${db_ok}" -eq 0 ]]; then
+        pgadmin_python setup-db
+        chown apache:apache /var/lib/pgadmin/pgadmin4.db 2>/dev/null || true
+        chmod 600 /var/lib/pgadmin/pgadmin4.db 2>/dev/null || true
+    fi
+
+    if ! pgadmin_python get-users --json 2>/dev/null | grep -q "${PGADMIN_EMAIL}"; then
+        pgadmin_python add-user "${PGADMIN_EMAIL}" "${PGADMIN_PASS}" --admin
+    else
+        log_info "pgAdmin user ${PGADMIN_EMAIL} already exists."
+    fi
+}
+
+install_systemd_unit() {
+    local gunicorn_py="${PGADMIN_VENV}/python3"
+    log_info "Installing pgadmin4.service (gunicorn on ${BIND_HOST}:${BIND_PORT})..."
+    cat > /etc/systemd/system/pgadmin4.service <<EOF
+[Unit]
+Description=pgAdmin 4 web (gunicorn)
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=apache
+Group=apache
+WorkingDirectory=${PGADMIN_WEB}
+Environment=PYTHONPATH=${PGADMIN_WEB}
+ExecStart=${gunicorn_py} -m gunicorn --bind ${BIND_HOST}:${BIND_PORT} --workers 2 --threads 4 --timeout 120 --chdir ${STACK_ROOT}/lib pgadmin_wsgi:application
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctl enable pgadmin4
+    systemctl restart pgadmin4
+    retry 10 5 systemctl is-active --quiet pgadmin4
+}
+
+install_pgadmin_repo
+configure_pgadmin_local
+setup_pgadmin_user
+install_systemd_unit
+
+code="$(curl -sk -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/login" 2>/dev/null || echo 000)"
+if echo "${code}" | grep -qE '200|302|301'; then
+    log_info "pgAdmin responding on http://${BIND_HOST}:${BIND_PORT}/ (HTTP ${code})"
+else
+    log_warn "pgAdmin may still be starting (HTTP ${code}); check: journalctl -u pgadmin4 -n 50"
+fi
+
+log_info "pgAdmin installed. Public URL after proxy: https://${PGADMIN_DOMAIN}/"

--- a/postgresql-stack/modules/45-pgadmin-server.sh
+++ b/postgresql-stack/modules/45-pgadmin-server.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Register the local PostgreSQL server in pgAdmin with a saved password.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_EMAIL="$(cfg_get pgadmin_email)"
+PGADMIN_PASS="$(cfg_get pgadmin_password)"
+PG_SUPER="$(cfg_get pg_superuser)"
+PG_SUPER_PASS="$(cfg_get pg_superuser_password)"
+PG_PORT="$(cfg_get pg_port)"
+PG_VER="$(cfg_get pg_version)"
+SERVER_NAME="PostgreSQL ${PG_VER} (localhost)"
+DISCOVERY_ID="POSTGRESQL_STACK/${PG_VER}"
+
+register_server() {
+    log_info "Registering pgAdmin server '${SERVER_NAME}'..."
+    export PGADMIN_EMAIL="${PGADMIN_EMAIL}"
+    export PGADMIN_PASSWORD="${PGADMIN_PASS}"
+    export PG_SUPERUSER="${PG_SUPER}"
+    export PG_SUPERUSER_PASSWORD="${PG_SUPER_PASS}"
+    export PG_HOST="127.0.0.1"
+    export PG_PORT="${PG_PORT}"
+    export PG_MAINT_DB="postgres"
+    export PG_SERVER_NAME="${SERVER_NAME}"
+    export PG_DISCOVERY_ID="${DISCOVERY_ID}"
+
+    local out
+    if ! out="$(/usr/pgadmin4/venv/bin/python3 "${STACK_ROOT}/lib/register_pg_server.py" 2>&1 | tee -a "${LOG_FILE}")"; then
+        log_error "Failed to register PostgreSQL server in pgAdmin."
+        return 1
+    fi
+    local gid sid
+    gid="$(echo "${out}" | sed -n 's/^SERVER_GID=//p' | tail -1)"
+    sid="$(echo "${out}" | sed -n 's/^SERVER_SID=//p' | tail -1)"
+    if [[ -n "${gid}" && -n "${sid}" ]]; then
+        if /usr/pgadmin4/venv/bin/python3 "${STACK_ROOT}/lib/update_sso_server_ids.py" "${gid}" "${sid}" >>"${LOG_FILE}" 2>&1; then
+            log_info "SSO secret updated with server_gid=${gid} server_sid=${sid}"
+        else
+            log_warn "Could not update SSO secret with server ids (run modules/55-sso.sh after SSO is configured)."
+        fi
+    fi
+}
+
+register_server
+
+count="$(sqlite3 /var/lib/pgadmin/pgadmin4.db "SELECT COUNT(*) FROM server WHERE discovery_id='${DISCOVERY_ID}';" 2>/dev/null || echo 0)"
+if [[ "${count}" -ge 1 ]]; then
+    log_info "OK: pgAdmin has registered server '${SERVER_NAME}'."
+else
+    log_warn "Server row not found after registration; check ${LOG_FILE}"
+fi
+
+# postgres-reg.ini auto-discovery creates passwordless duplicate servers; do not use it.
+if [[ -f /etc/postgres-reg.ini ]] && grep -q "POSTGRESQL_STACK" /etc/postgres-reg.ini 2>/dev/null; then
+    log_info "Removing legacy postgres-reg.ini stack entry (causes duplicate servers)..."
+    sed -i '/\[PostgreSQL\/POSTGRESQL_STACK/,/^$/d' /etc/postgres-reg.ini
+fi
+
+log_info "Server registration complete. After SSO login, pick '${SERVER_NAME}' in Query Tool or connect from the Browser tree."

--- a/postgresql-stack/modules/47-pgadmin-patches.sh
+++ b/postgresql-stack/modules/47-pgadmin-patches.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Patch pgAdmin for Query Tool workspace server dropdown (lazy CSRF API client).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bash "${STACK_ROOT}/lib/apply_pgadmin_patches.sh"

--- a/postgresql-stack/modules/50-subdomain-proxy.sh
+++ b/postgresql-stack/modules/50-subdomain-proxy.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Create CyberPanel child domain and configure LiteSpeed reverse proxy to pgAdmin.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+MASTER_DOMAIN="$(cfg_get master_domain)"
+OWNER="$(cfg_get cyberpanel_owner)"
+PHP_VER="$(cfg_get cyberpanel_php)"
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+DOCROOT="/home/${MASTER_DOMAIN}/${PGADMIN_DOMAIN}"
+VHOST_CONF="/usr/local/lsws/conf/vhosts/${PGADMIN_DOMAIN}/vhost.conf"
+MARKER="# POSTGRESQL_STACK_PROXY"
+
+create_child_domain() {
+    if [[ -f "${VHOST_CONF}" ]]; then
+        log_info "Vhost already exists: ${VHOST_CONF}"
+        return 0
+    fi
+    log_info "Creating child domain ${PGADMIN_DOMAIN} under ${MASTER_DOMAIN}..."
+    retry 3 10 cyberpanel createChild \
+        --masterDomain "${MASTER_DOMAIN}" \
+        --childDomain "${PGADMIN_DOMAIN}" \
+        --owner "${OWNER}" \
+        --php "${PHP_VER}" \
+        --ssl 1 \
+        --path "${PGADMIN_DOMAIN}" || {
+            log_warn "createChild returned non-zero; checking vhost again."
+        }
+    sleep 5
+    if [[ ! -f "${VHOST_CONF}" ]]; then
+        log_error "Failed to create vhost ${VHOST_CONF}. Check CyberPanel owner (${OWNER}) and DNS."
+        exit 1
+    fi
+}
+
+issue_ssl() {
+    log_info "Issuing SSL for ${PGADMIN_DOMAIN}..."
+    retry 3 15 cyberpanel issueSSL --domainName "${PGADMIN_DOMAIN}" || \
+        log_warn "SSL issuance may need DNS propagation; retry later."
+}
+
+write_docroot_htaccess() {
+    mkdir -p "${DOCROOT}/.well-known/acme-challenge"
+    cat > "${DOCROOT}/.htaccess" <<'EOF'
+# postgresql-stack: proxy handled in vhost.conf (ExtProcessor pgadmin4)
+RewriteEngine On
+RewriteCond %{HTTPS} !=on
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+<Files "config.php">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<Files ".env*">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<FilesMatch "\.(log|sql|bak|backup|key|pem|crt|tmp|temp|cache)$">
+    Order Allow,Deny
+    Deny from all
+</FilesMatch>
+EOF
+    chown newst3922:nobody "${DOCROOT}" 2>/dev/null || true
+    find "${DOCROOT}" -exec chown newst3922:newst3922 {} \; 2>/dev/null || true
+    chmod 755 "${DOCROOT}"
+    chmod 644 "${DOCROOT}/.htaccess"
+}
+
+configure_vhost_proxy() {
+    if [[ ! -f "${VHOST_CONF}" ]]; then
+        log_error "Vhost not found: ${VHOST_CONF}. Create domain in CyberPanel first."
+        exit 1
+    fi
+
+    fix_acme_challenge_context
+
+    if grep -q "${MARKER}" "${VHOST_CONF}"; then
+        log_info "Reverse proxy already configured in vhost."
+        return 0
+    fi
+
+    log_info "Patching vhost.conf for pgAdmin reverse proxy..."
+    cp -a "${VHOST_CONF}" "${VHOST_CONF}.bak.postgresql-stack"
+
+    # Remove default PHP scripthandler block if present (proxy replaces it)
+    python3 <<PY
+from pathlib import Path
+import re
+
+path = Path("${VHOST_CONF}")
+text = path.read_text()
+marker = "${MARKER}"
+
+proxy_block = f'''
+{marker}
+extprocessor pgadmin4 {{
+  type                    proxy
+  address                 http://${BIND_HOST}:${BIND_PORT}
+  maxConns                60
+  pcKeepAliveTimeout      -1
+  initTimeout             60
+  retryTimeout            60
+  respBuffer              0
+}}
+
+context / {{
+  type                    proxy
+  handler                 pgadmin4
+  addDefaultCharset       off
+}}
+'''
+
+# Strip existing scripthandler / extprocessor lsapi blocks for clean proxy
+text = re.sub(r'scripthandler\s*\{[^}]*\}\s*', '', text, flags=re.DOTALL)
+text = re.sub(r'extprocessor\s+\w+\s*\{[^}]*type\s+lsapi[^}]*\}\s*', '', text, flags=re.DOTALL)
+
+if 'rewrite  {' in text:
+    text = re.sub(
+        r'rewrite\s*\{[^}]*autoLoadHtaccess\s+1[^}]*\}',
+        'rewrite  {\\n  enable                  1\\n  autoLoadHtaccess        1\\n}',
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+if 'vhssl {' in text:
+    parts = text.split('vhssl {', 1)
+    text = parts[0].rstrip() + '\\n' + proxy_block + '\\nvhssl {' + parts[1]
+else:
+    text = text.rstrip() + '\\n' + proxy_block
+
+path.write_text(text)
+PY
+
+    log_info "vhost.conf updated."
+}
+
+fix_acme_challenge_context() {
+    if [[ ! -f "${VHOST_CONF}" ]]; then
+        return 0
+    fi
+    local challenge_dir="${DOCROOT}/.well-known/acme-challenge"
+    mkdir -p "${challenge_dir}"
+    chmod 755 "${DOCROOT}/.well-known" "${challenge_dir}" 2>/dev/null || true
+    find "${DOCROOT}/.well-known" -exec chown newst3922:newst3922 {} \; 2>/dev/null || true
+
+    TARGET="${VHOST_CONF}" CHALLENGE_DIR="${challenge_dir}" python3 <<'PY'
+import os, re
+from pathlib import Path
+
+path = Path(os.environ["TARGET"])
+challenge_dir = os.environ["CHALLENGE_DIR"]
+text = path.read_text()
+
+block = f'''context /.well-known/acme-challenge {{
+  location                {challenge_dir}
+  allowBrowse             1
+
+  rewrite  {{
+     enable                  0
+  }}
+  addDefaultCharset       off
+
+  phpIniOverride  {{
+
+  }}
+}}'''
+
+if 'context /.well-known/acme-challenge' in text:
+    text = re.sub(
+        r'context /\.well-known/acme-challenge\s*\{.*?\n\}',
+        block,
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+else:
+    anchor = 'rewrite  {'
+    if anchor not in text:
+        raise SystemExit('rewrite block not found in vhost.conf')
+    text = text.replace(anchor, block + '\n\n' + anchor, 1)
+
+path.write_text(text)
+print('acme challenge context updated')
+PY
+    log_info "ACME challenge path set to ${challenge_dir}"
+}
+
+create_child_domain
+write_docroot_htaccess
+configure_vhost_proxy
+issue_ssl
+restart_lsws
+
+log_info "Reverse proxy configured: https://${PGADMIN_DOMAIN}/ -> http://${BIND_HOST}:${BIND_PORT}/"

--- a/postgresql-stack/modules/55-sso.sh
+++ b/postgresql-stack/modules/55-sso.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Configure one-click SSO launcher for pgAdmin.
+# - Generates a per-install SSO token (stored in config.php).
+# - Writes an apache-readable secret file consumed by lib/pgadmin_wsgi.py.
+# - Disables the pgAdmin master-password prompt for frictionless entry.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+SECRET_FILE="/var/lib/pgadmin/.pgstack-sso.json"
+LOCAL_CFG="/usr/pgadmin4/web/config_local.py"
+
+ensure_token() {
+    local token
+    token="$(cfg_get pgadmin_sso_token 2>/dev/null || true)"
+    if [[ -z "${token}" || "${token}" == "missing key" ]]; then
+        token="$(gen_secret 48)"
+        update_config_value "pgadmin_sso_token" "${token}"
+        log_info "Generated new pgAdmin SSO token."
+    else
+        log_info "Existing pgAdmin SSO token preserved."
+    fi
+}
+
+write_secret_file() {
+    local token email pass bhost bport
+    token="$(cfg_get pgadmin_sso_token)"
+    email="$(cfg_get pgadmin_email)"
+    pass="$(cfg_get pgadmin_password)"
+    bhost="$(cfg_get pgadmin_bind_host)"
+    bport="$(cfg_get pgadmin_bind_port)"
+
+    mkdir -p /var/lib/pgadmin
+    TOKEN="${token}" EMAIL="${email}" PASS="${pass}" BHOST="${bhost}" BPORT="${bport}" \
+    SECRET_FILE="${SECRET_FILE}" python3 <<'PY'
+import json, os
+path = os.environ["SECRET_FILE"]
+existing = {}
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        existing = json.load(fh)
+except Exception:
+    pass
+data = {
+    "token": os.environ["TOKEN"],
+    "email": os.environ["EMAIL"],
+    "password": os.environ["PASS"],
+    "backend_host": os.environ.get("BHOST") or "127.0.0.1",
+    "backend_port": int(os.environ.get("BPORT") or 5050),
+}
+for key in ("server_gid", "server_sid"):
+    if key in existing:
+        data[key] = existing[key]
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh)
+PY
+    chown apache:apache "${SECRET_FILE}" 2>/dev/null || true
+    chmod 600 "${SECRET_FILE}"
+    log_info "Wrote SSO secret file (chmod 600, apache-owned): ${SECRET_FILE}"
+}
+
+set_pgadmin_flag() {
+    local key="$1" value="$2"
+    if grep -q "^${key}" "${LOCAL_CFG}"; then
+        sed -i "s/^${key}.*/${key} = ${value}/" "${LOCAL_CFG}"
+    else
+        echo "${key} = ${value}" >> "${LOCAL_CFG}"
+    fi
+}
+
+tune_pgadmin_for_sso() {
+    if [[ ! -f "${LOCAL_CFG}" ]]; then
+        log_warn "pgAdmin config_local.py not found; skipping SSO tuning."
+        return 0
+    fi
+    # Frictionless: no master-password prompt on first/each login.
+    set_pgadmin_flag "MASTER_PASSWORD_REQUIRED" "False"
+    # Required for SSO: the launcher logs in server-side, so the session must not
+    # be bound to the IP/User-Agent (Paranoid/ENHANCED_COOKIE_PROTECTION).
+    set_pgadmin_flag "ENHANCED_COOKIE_PROTECTION" "False"
+    log_info "Tuned pgAdmin for SSO (MASTER_PASSWORD_REQUIRED=False, ENHANCED_COOKIE_PROTECTION=False)."
+}
+
+restart_pgadmin() {
+    log_info "Restarting pgadmin4 to load SSO launcher..."
+    systemctl restart pgadmin4
+    retry 10 5 systemctl is-active --quiet pgadmin4
+}
+
+ensure_token
+write_secret_file
+tune_pgadmin_for_sso
+restart_pgadmin
+
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+TOKEN="$(cfg_get pgadmin_sso_token)"
+sleep 2
+good="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=${TOKEN}" 2>/dev/null || echo 000)"
+bad="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=invalid" 2>/dev/null || echo 000)"
+if [[ "${good}" == "302" ]]; then
+    log_info "OK: SSO launcher auto-login works (HTTP 302 with valid token)."
+else
+    log_warn "SSO launcher returned HTTP ${good} for valid token (expected 302); check journalctl -u pgadmin4."
+fi
+if [[ "${bad}" == "403" ]]; then
+    log_info "OK: SSO launcher rejects invalid token (HTTP 403)."
+else
+    log_warn "SSO launcher returned HTTP ${bad} for invalid token (expected 403)."
+fi
+
+log_info "SSO configured. Tile opens: https://$(cfg_get pgadmin_domain)/sso/?key=<token>"

--- a/postgresql-stack/modules/60-tile.sh
+++ b/postgresql-stack/modules/60-tile.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Inject PostgreSQL/pgAdmin card into CyberPanel Quick App Installer.
+# Target: websiteFunctions/templates/websiteFunctions/website.html (.app-grid).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+SSO_TOKEN="$(cfg_get pgadmin_sso_token 2>/dev/null || true)"
+WEBSITE_HTML="/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/website.html"
+LEGACY_HTML="/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/applicationInstaller.html"
+ICON_DIR="/usr/local/CyberCP/public/static/images/icons"
+ICON_FILE="${ICON_DIR}/postgresql.png"
+MARKER="POSTGRESQL_STACK_TILE"
+if [[ -n "${SSO_TOKEN}" && "${SSO_TOKEN}" != "missing key" ]]; then
+    TILE_URL="https://${PGADMIN_DOMAIN}/sso/?key=${SSO_TOKEN}"
+else
+    TILE_URL="https://${PGADMIN_DOMAIN}/"
+fi
+
+install_icon() {
+    mkdir -p "${ICON_DIR}"
+    if [[ -f "${ICON_FILE}" ]]; then
+        log_info "PostgreSQL icon already present."
+    else
+        log_info "Installing PostgreSQL icon for CyberPanel tile..."
+        if curl -sfL "https://www.postgresql.org/media/img/about/press/elephant.png" -o "${ICON_FILE}.tmp" 2>/dev/null; then
+            mv "${ICON_FILE}.tmp" "${ICON_FILE}"
+            chmod 644 "${ICON_FILE}"
+        else
+            touch "${ICON_FILE}"
+            log_warn "Could not download icon; placeholder created at ${ICON_FILE}."
+        fi
+    fi
+
+    for dest in \
+        "/usr/local/CyberCP/static/images/icons/postgresql.png" \
+        "/usr/local/CyberCP/websiteFunctions/static/images/icons/postgresql.png"; do
+        mkdir -p "$(dirname "${dest}")"
+        cp -f "${ICON_FILE}" "${dest}" 2>/dev/null || true
+    done
+}
+
+clean_legacy_injection() {
+    if [[ -f "${LEGACY_HTML}" ]] && grep -q "${MARKER}" "${LEGACY_HTML}"; then
+        log_info "Removing stale tile from legacy applicationInstaller.html..."
+        TARGET="${LEGACY_HTML}" MARK="${MARKER}" python3 <<'PY'
+import os, re
+from pathlib import Path
+path = Path(os.environ["TARGET"])
+mark = os.environ["MARK"]
+text = path.read_text()
+text = re.sub(r"\n\s*<!-- " + re.escape(mark) + r" -->.*?</a>\n", "\n", text, flags=re.DOTALL)
+path.write_text(text)
+PY
+    fi
+}
+
+patch_website_ui() {
+    if [[ ! -f "${WEBSITE_HTML}" ]]; then
+        return 0
+    fi
+    if grep -q "POSTGRESQL_STACK_UI_FIX" "${WEBSITE_HTML}"; then
+        log_info "Website UI cloak patch already present."
+        return 0
+    fi
+
+    log_info "Patching website.html domain form (hide until Angular, ng-cloak)..."
+    TARGET="${WEBSITE_HTML}" python3 <<'PY'
+from pathlib import Path
+import os
+
+path = Path(os.environ["TARGET"])
+text = path.read_text()
+marker = "<!-- POSTGRESQL_STACK_UI_FIX -->"
+
+old_form = (
+    '<form id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+    '                                  class="form-horizontal bordered-row">'
+)
+new_form = (
+    marker + '\n'
+    '                            <form id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+    '                                  class="form-horizontal bordered-row" style="display:none;" ng-cloak>'
+)
+if old_form in text:
+    text = text.replace(old_form, new_form, 1)
+elif 'POSTGRESQL_STACK_UI_FIX' not in text and 'id="domainCreationForm"' in text:
+    text = text.replace(
+        'id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+        '                                  class="form-horizontal bordered-row"',
+        marker + '\n'
+        '                            <form id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+        '                                  class="form-horizontal bordered-row" style="display:none;" ng-cloak',
+        1,
+    )
+
+old_block = '''                                <div ng-hide="installationProgress" class="form-group">
+                                    <label class="col-sm-2 control-label"></label>
+                                    <div class="col-sm-7">
+
+                                        <div class="alert alert-success text-center">
+                                            <h2>{$ currentStatus $}</h2>
+                                        </div>'''
+new_block = '''                                <div ng-hide="installationProgress" class="form-group" ng-cloak>
+                                    <label class="col-sm-2 control-label"></label>
+                                    <div class="col-sm-7">
+
+                                        <div class="alert alert-success text-center">
+                                            <h2>{$ currentStatus $}</h2>
+                                        </div>'''
+if old_block in text:
+    text = text.replace(old_block, new_block, 1)
+
+for old, new in [
+    ('<div ng-hide="errorMessageBox" class="alert alert-danger">', '<div ng-hide="errorMessageBox" class="alert alert-danger" ng-cloak>'),
+    ('<div ng-hide="success" class="alert alert-success">\n                                            <p>{% trans "Website succesfully created." %}</p>',
+     '<div ng-hide="success" class="alert alert-success" ng-cloak>\n                                            <p>{% trans "Website succesfully created." %}</p>'),
+    ('<div ng-hide="couldNotConnect" class="alert alert-danger">\n                                            <p>{% trans "Could not connect to server. Please refresh this page." %}</p>',
+     '<div ng-hide="couldNotConnect" class="alert alert-danger" ng-cloak>\n                                            <p>{% trans "Could not connect to server. Please refresh this page." %}</p>'),
+]:
+  if old in text:
+    text = text.replace(old, new, 1)
+
+go_back_old = '''                                <div ng-hide="installationProgress" class="form-group">
+                                    <label class="col-sm-3 control-label"></label>
+                                    <div class="col-sm-4">
+                                        <button type="button" ng-disabled="goBackDisable" ng-click="goBack()"'''
+go_back_new = '''                                <div ng-hide="installationProgress" class="form-group" ng-cloak>
+                                    <label class="col-sm-3 control-label"></label>
+                                    <div class="col-sm-4">
+                                        <button type="button" ng-disabled="goBackDisable" ng-click="goBack()"'''
+if go_back_old in text:
+    text = text.replace(go_back_old, go_back_new, 1)
+
+path.write_text(text)
+print("ui patched")
+PY
+}
+
+inject_card() {
+    if [[ ! -f "${WEBSITE_HTML}" ]]; then
+        log_error "CyberPanel website.html not found: ${WEBSITE_HTML}"
+        exit 1
+    fi
+    if grep -q "${MARKER}" "${WEBSITE_HTML}"; then
+        log_info "PostgreSQL card already present in Quick App Installer."
+        return 0
+    fi
+
+    log_info "Injecting PostgreSQL/pgAdmin card into Quick App Installer (website.html)..."
+    cp -a "${WEBSITE_HTML}" "${WEBSITE_HTML}.bak.postgresql-stack.$(date +%Y%m%d%H%M%S)"
+
+    TARGET="${WEBSITE_HTML}" MARK="${MARKER}" TILEURL="${TILE_URL}" python3 <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["TARGET"])
+mark = os.environ["MARK"]
+url = os.environ["TILEURL"]
+text = path.read_text()
+
+card = (
+    "                <!-- " + mark + " -->\n"
+    "                <a href=\"" + url + "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"app-card postgresql\">\n"
+    "                    <div class=\"quick-badge\">Database</div>\n"
+    "                    <div class=\"app-icon-wrapper\">\n"
+    "                        <img src=\"{% static 'images/icons/postgresql.png' %}\" alt=\"PostgreSQL\" class=\"app-icon\">\n"
+    "                    </div>\n"
+    "                    <h3 class=\"app-name\">PostgreSQL / pgAdmin</h3>\n"
+    "                    <p class=\"app-description\">{% trans \"PostgreSQL database administration via pgAdmin 4\" %}</p>\n"
+    "                    <div class=\"app-features\">\n"
+    "                        <span class=\"feature-tag\">pgAdmin</span>\n"
+    "                        <span class=\"feature-tag\">pg_cron</span>\n"
+    "                        <span class=\"feature-tag\">SQL</span>\n"
+    "                    </div>\n"
+    "                    <div class=\"install-btn\">\n"
+    "                        <i class=\"fas fa-database\"></i>\n"
+    "                        {% trans \"Open pgAdmin\" %}\n"
+    "                    </div>\n"
+    "                </a>\n"
+)
+
+# Insert after the Mautic card (the last card in the Quick App Installer grid).
+# fa-chart-line is unique to the Mautic install button, so this anchors the
+# correct grid rather than the management-tools grid above it.
+anchor = (
+    "                        <i class=\"fas fa-chart-line\"></i>\n"
+    "                        {% trans \"Install Now\" %}\n"
+    "                    </div>\n"
+    "                </a>\n"
+)
+if anchor not in text:
+    raise SystemExit("Mautic card anchor not found in website.html; aborting injection")
+
+text = text.replace(anchor, anchor + card, 1)
+path.write_text(text)
+print("card injected")
+PY
+
+    log_info "Card injected. Re-apply after CyberPanel upgrades: ${STACK_ROOT}/reapply-tile.sh"
+}
+
+update_tile_href() {
+    if [[ ! -f "${WEBSITE_HTML}" ]] || ! grep -q "${MARKER}" "${WEBSITE_HTML}"; then
+        return 0
+    fi
+    TARGET="${WEBSITE_HTML}" MARK="${MARKER}" TILEURL="${TILE_URL}" python3 <<'PY'
+import os, re
+from pathlib import Path
+
+path = Path(os.environ["TARGET"])
+mark = os.environ["MARK"]
+url = os.environ["TILEURL"]
+text = path.read_text()
+
+# Update the href on the tile anchor immediately following our marker comment.
+pattern = re.compile(
+    r'(<!-- ' + re.escape(mark) + r' -->\s*\n\s*<a href=")[^"]*(")'
+)
+new_text, n = pattern.subn(r'\g<1>' + url.replace('\\', r'\\') + r'\g<2>', text, count=1)
+if n and new_text != text:
+    path.write_text(new_text)
+    print("tile href updated")
+else:
+    print("tile href unchanged")
+PY
+}
+
+install_icon
+clean_legacy_injection
+patch_website_ui
+inject_card
+update_tile_href

--- a/postgresql-stack/modules/90-verify.sh
+++ b/postgresql-stack/modules/90-verify.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Post-install verification with retries.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+CRON_DB="$(cfg_get pg_cron_database)"
+FAIL=0
+
+check_service() {
+    local svc="$1"
+    if systemctl is-active --quiet "${svc}"; then
+        log_info "OK: service ${svc} is active"
+        return 0
+    fi
+    log_error "FAIL: service ${svc} is not active"
+    FAIL=1
+    return 1
+}
+
+check_psql() {
+    if sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -c 'SELECT 1;' >/dev/null 2>&1; then
+        log_info "OK: psql connects as postgres"
+        return 0
+    fi
+    log_error "FAIL: psql connection failed"
+    FAIL=1
+    return 1
+}
+
+check_pg_cron() {
+    if sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -d "${CRON_DB}" -tAc \
+        "SELECT 1 FROM pg_extension WHERE extname='pg_cron';" 2>/dev/null | grep -q 1; then
+        log_info "OK: pg_cron extension present"
+        return 0
+    fi
+    log_error "FAIL: pg_cron extension missing"
+    FAIL=1
+    return 1
+}
+
+check_system_stats() {
+    if sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -d postgres -tAc \
+        "SELECT 1 FROM pg_extension WHERE extname='system_stats';" 2>/dev/null | grep -q 1; then
+        log_info "OK: system_stats extension present (pgAdmin Dashboard System tab)"
+        return 0
+    fi
+    log_warn "system_stats extension missing; pgAdmin System tab limited (run modules/10-postgresql.sh)"
+    return 0
+}
+
+check_pgadmin_local() {
+    local code
+    code="$(curl -sk -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/login" 2>/dev/null || echo 000)"
+    if echo "${code}" | grep -qE '200|302|301'; then
+        log_info "OK: pgAdmin local backend HTTP ${code}"
+        return 0
+    fi
+    log_error "FAIL: pgAdmin local backend returned HTTP ${code}"
+    FAIL=1
+    return 1
+}
+
+check_pgadmin_server() {
+    local pg_ver count
+    pg_ver="$(cfg_get pg_version)"
+    count="$(sqlite3 /var/lib/pgadmin/pgadmin4.db "SELECT COUNT(*) FROM server WHERE discovery_id='POSTGRESQL_STACK/${pg_ver}';" 2>/dev/null || echo 0)"
+    if [[ "${count}" -ge 1 ]]; then
+        log_info "OK: pgAdmin has registered PostgreSQL server (POSTGRESQL_STACK/${pg_ver})"
+        return 0
+    fi
+    log_error "FAIL: pgAdmin server registration missing (run modules/45-pgadmin-server.sh)"
+    FAIL=1
+    return 1
+}
+
+check_sso() {
+    local token good bad
+    token="$(cfg_get pgadmin_sso_token 2>/dev/null || true)"
+    if [[ -z "${token}" || "${token}" == "missing key" ]]; then
+        log_warn "SSO token not configured; skipping SSO check."
+        return 0
+    fi
+    good="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=${token}" 2>/dev/null || echo 000)"
+    bad="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=invalid" 2>/dev/null || echo 000)"
+    if [[ "${good}" == "302" && "${bad}" == "403" ]]; then
+        log_info "OK: SSO auto-login (302 valid token, 403 invalid token)"
+    else
+        log_error "FAIL: SSO check (valid=${good} expected 302, invalid=${bad} expected 403)"
+        FAIL=1
+        return 1
+    fi
+
+    local cj ref csrf hdr gid sid count sess
+    cj="$(mktemp)"
+    ref="https://${PGADMIN_DOMAIN}/browser/"
+    sess="$(curl -sk -H "Host: ${PGADMIN_DOMAIN}" \
+        --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+        -D - "https://${PGADMIN_DOMAIN}/sso/?key=${token}" -o /dev/null 2>/dev/null | \
+        sed -n 's/.*pga4_session=\([^;]*\).*/\1/p' | head -1)"
+    if [[ -z "${sess}" ]]; then
+        log_warn "SSO session cookie not returned; skipping post-login API checks."
+        rm -f "${cj}"
+        return 0
+    fi
+    curl -sk -H "Host: ${PGADMIN_DOMAIN}" -H "Cookie: pga4_session=${sess}" \
+        --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+        "https://${PGADMIN_DOMAIN}/browser/js/utils.js" -o /tmp/pgstack-utils.js 2>/dev/null || true
+    csrf="$(sed -n "s/.*pgAdmin\['csrf_token'\] = '\([^']*\)'.*/\1/p" /tmp/pgstack-utils.js | head -1)"
+    hdr="$(sed -n "s/.*pgAdmin\['csrf_token_header'\] = '\([^']*\)'.*/\1/p" /tmp/pgstack-utils.js | head -1)"
+    if [[ -z "${csrf}" || -z "${hdr}" ]]; then
+        log_warn "SSO session CSRF not available; skipping post-login API checks."
+        rm -f "${cj}"
+        return 0
+    fi
+    gid="$(python3 -c "import json;print(json.load(open('/var/lib/pgadmin/.pgstack-sso.json')).get('server_gid',''))" 2>/dev/null || true)"
+    sid="$(python3 -c "import json;print(json.load(open('/var/lib/pgadmin/.pgstack-sso.json')).get('server_sid',''))" 2>/dev/null || true)"
+    if [[ -n "${gid}" && -n "${sid}" ]]; then
+        local conn_code
+        conn_code="$(curl -sk -H "Host: ${PGADMIN_DOMAIN}" -H "Cookie: pga4_session=${sess}" \
+            -X POST -H "${hdr}: ${csrf}" -H "Referer: ${ref}" -H "Content-Type: application/json" -d '{}' \
+            --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+            "https://${PGADMIN_DOMAIN}/browser/server/connect/${gid}/${sid}" \
+            -o /tmp/pgstack-conn.json -w '%{http_code}' 2>/dev/null || echo 000)"
+        if [[ "${conn_code}" == "200" ]]; then
+            log_info "OK: SSO post-login server connect (gid=${gid} sid=${sid})"
+        else
+            log_warn "SSO post-login connect returned HTTP ${conn_code} (gid=${gid} sid=${sid})"
+        fi
+    fi
+    count="$(curl -sk -H "Host: ${PGADMIN_DOMAIN}" -H "Cookie: pga4_session=${sess}" \
+        -H "${hdr}: ${csrf}" -H "Referer: ${ref}" \
+        --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+        "https://${PGADMIN_DOMAIN}/sqleditor/new_connection_dialog" 2>/dev/null | \
+        python3 -c "import sys,json;d=json.load(sys.stdin);print(len(d.get('data',{}).get('result',{}).get('server_list',{}).get('Servers',[])))" 2>/dev/null || echo 0)"
+    rm -f "${cj}"
+    if [[ "${count}" -ge 1 ]]; then
+        log_info "OK: Query Tool server list API returns ${count} server(s) after SSO"
+        return 0
+    fi
+    log_warn "Query Tool server list API returned 0 servers after SSO"
+    return 0
+}
+
+check_public_url() {
+    local code
+    code="$(curl -sk -o /dev/null -w '%{http_code}' "https://${PGADMIN_DOMAIN}/login" 2>/dev/null || echo 000)"
+    if echo "${code}" | grep -qE '200|302|301'; then
+        log_info "OK: public URL https://${PGADMIN_DOMAIN}/ returned HTTP ${code}"
+        return 0
+    fi
+    code="$(curl -sk -o /dev/null -w '%{http_code}' --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" "https://${PGADMIN_DOMAIN}/login" 2>/dev/null || echo 000)"
+    if echo "${code}" | grep -qE '200|302|301'; then
+        log_info "OK: reverse proxy via LiteSpeed returned HTTP ${code} (DNS may need A record for ${PGADMIN_DOMAIN})"
+        return 0
+    fi
+    log_warn "Public URL returned HTTP ${code}; add DNS A record for ${PGADMIN_DOMAIN} and re-run: cyberpanel issueSSL --domainName ${PGADMIN_DOMAIN}"
+    return 0
+}
+
+retry 3 5 check_service "${PG_SVC}"
+retry 3 5 check_service pgadmin4
+retry 5 5 check_psql
+retry 3 5 check_pg_cron
+check_system_stats
+retry 8 5 check_pgadmin_local
+retry 3 5 check_pgadmin_server
+retry 3 5 check_sso
+check_public_url
+
+if [[ "${FAIL}" -ne 0 ]]; then
+    log_error "Verification failed. See ${LOG_FILE}"
+    exit 1
+fi
+
+log_info "All critical verification checks passed."

--- a/postgresql-stack/reapply-tile.sh
+++ b/postgresql-stack/reapply-tile.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Re-apply CyberPanel Quick App tile after panel upgrades.
+set -euo pipefail
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${STACK_ROOT}/modules/60-tile.sh"

--- a/postgresql-stack/sql/bootstrap.sql
+++ b/postgresql-stack/sql/bootstrap.sql
@@ -1,0 +1,14 @@
+-- Bootstrap roles for postgresql-stack (run as postgres superuser).
+-- Placeholders __PG_APP_USER__ and __PG_APP_PASSWORD__ are replaced by the installer.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '__PG_APP_USER__') THEN
+        CREATE ROLE __PG_APP_USER__ LOGIN PASSWORD '__PG_APP_PASSWORD__';
+    ELSE
+        ALTER ROLE __PG_APP_USER__ WITH PASSWORD '__PG_APP_PASSWORD__';
+    END IF;
+END
+$$;
+
+GRANT CONNECT ON DATABASE postgres TO __PG_APP_USER__;

--- a/postgresql-stack/uninstall.sh
+++ b/postgresql-stack/uninstall.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Remove PostgreSQL stack (services, tile, optional data purge).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+PURGE_DATA=0
+REMOVE_TILE=1
+
+usage() {
+    echo "Usage: $0 [--purge-data] [--keep-tile]"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --purge-data) PURGE_DATA=1; shift ;;
+        --keep-tile) REMOVE_TILE=0; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+require_root
+
+if [[ -f "${CONFIG_PHP}" ]]; then
+    load_config
+    PG_VER="$(cfg_get pg_version)"
+    PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+else
+    PG_VER="17"
+    PGADMIN_DOMAIN="pgadmin.newstargeted.com"
+fi
+
+log_info "Stopping pgAdmin service..."
+systemctl stop pgadmin4 2>/dev/null || true
+systemctl disable pgadmin4 2>/dev/null || true
+rm -f /etc/systemd/system/pgadmin4.service
+systemctl daemon-reload
+
+log_info "Removing SSO secret file..."
+rm -f /var/lib/pgadmin/.pgstack-sso.json
+
+if [[ "${REMOVE_TILE}" -eq 1 ]]; then
+    for html in \
+        "/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/website.html" \
+        "/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/applicationInstaller.html"; do
+        if [[ -f "${html}" ]] && grep -q "POSTGRESQL_STACK_TILE" "${html}"; then
+            log_info "Removing PostgreSQL card from $(basename "${html}")..."
+            TARGET="${html}" python3 <<'PY'
+import os, re
+from pathlib import Path
+path = Path(os.environ["TARGET"])
+text = path.read_text()
+text = re.sub(r"\n\s*<!-- POSTGRESQL_STACK_TILE -->.*?</a>\n", "\n", text, flags=re.DOTALL)
+path.write_text(text)
+PY
+        fi
+    done
+fi
+
+log_info "PostgreSQL server left installed by default (shared system service)."
+log_info "To remove packages: dnf remove postgresql${PG_VER}-server pgadmin4-web pg_cron_${PG_VER}"
+
+if [[ "${PURGE_DATA}" -eq 1 ]]; then
+    read -r -p "Purge PostgreSQL data directory? This destroys all databases [y/N]: " ans
+    if [[ "${ans}" == "y" || "${ans}" == "Y" ]]; then
+        systemctl stop "postgresql-${PG_VER}" 2>/dev/null || true
+        rm -rf "/var/lib/pgsql/${PG_VER}"
+        log_warn "PostgreSQL data purged."
+    fi
+fi
+
+log_info "Uninstall steps completed. Remove child domain ${PGADMIN_DOMAIN} manually in CyberPanel if desired."

--- a/to-do/POSTGRESQL-STACK.md
+++ b/to-do/POSTGRESQL-STACK.md
@@ -1,0 +1,61 @@
+# PostgreSQL stack (optional addon)
+
+Optional **PostgreSQL 17 + pg_cron + pgAdmin 4** stack for CyberPanel on AlmaLinux/RHEL 9+.
+
+Shipped in-repo at `/usr/local/CyberCP/postgresql-stack/` after panel install or upgrade sync.
+
+## Install (new panel)
+
+Interactive installer:
+
+```bash
+sh <(curl https://cyberpanel.net/install.sh || wget -O - https://cyberpanel.net/install.sh)
+```
+
+Answer **Yes** when asked about the PostgreSQL stack, or use:
+
+```bash
+sh cyberpanel.sh --postgresql-stack
+```
+
+## Install (existing server, manual)
+
+From the live panel tree:
+
+```bash
+cd /usr/local/CyberCP/postgresql-stack
+./install.sh --master-domain example.com --domain pgadmin.example.com
+```
+
+Secrets are written to `config.php` (chmod 600, not in git).
+
+## Upgrade
+
+On upgrade, if `config.php` already exists the upgrade script:
+
+1. Keeps existing secrets
+2. Refreshes pgAdmin patches and the CyberPanel Quick App tile
+3. Restarts `pgadmin4` if the unit is installed
+
+Fresh optional install after upgrade:
+
+```bash
+/usr/local/CyberCP/postgresql-stack/install.sh
+```
+
+## Uninstall
+
+```bash
+/usr/local/CyberCP/postgresql-stack/uninstall.sh
+```
+
+Use `--purge-data` only when you intend to remove PostgreSQL data.
+
+## Branches
+
+| Branch | Status |
+|--------|--------|
+| `v3.0.5-dev` | Integrated in `cyberpanel.sh` and `cyberpanel_upgrade.sh` |
+| `v3.0.4` | Stack files included; manual or `--postgresql-stack` install |
+
+Fork reference: [master3395/cyberpanel v3.0.4](https://github.com/master3395/cyberpanel/tree/v3.0.4)


### PR DESCRIPTION
## Summary

Restores the Banned IPs panel APIs, model, migrations, and JS wiring that were dropped in the v3 cutover while the firewall UI still expected them.

Replaces part of #1901 (keep #1901 open as reference). Base: `usmannasir:v3.0.4-dev` (`24b648f2`).

## Changes

### Fixes / updates

- Restore `BannedIP` model and Django migrations (`0001` to `0003`, including `sortOrder`)
- Restore manager methods and URL routes for get/add/remove banned IPs
- Align `firewall.js` client with restored endpoints

### Files

- `firewall/firewallManager.py`
- `firewall/models.py`
- `firewall/views.py`
- `firewall/urls.py`
- `firewall/static/firewall/firewall.js`
- `firewall/migrations/*`

## Tests / smoke

| Check | Result |
|-------|--------|
| `py_compile` on touched Python | PASS |
| Live panel: Security > Firewall > Banned IPs tab | NOT RUN |
| Ban / unban test IP from UI | NOT RUN |
| `python manage.py showmigrations firewall` | NOT RUN |
| Docker / Hyper-V smoke | SKIPPED (no Docker CLI) |

Environment: Windows Cursor Local, 27/08/2026.

## Out of scope

- Auto-ban plugins (`fail2ban`, `autoBanSecurityAlerts`)
- Dashboard SSH alert ban button / live-ops systemd units
- Installer, Docker, Hyper-V, UI theme work
- Planning docs under `to-do/`

## Notes

Single-commit slice; merge-base is current upstream `v3.0.4-dev` tip.
