### PR TITLE
fix(login): restore webauthn static, CSP Insights, password rehash

### DIFF
--- a/CyberCP/secMiddleware.py
+++ b/CyberCP/secMiddleware.py
@@ -13,7 +13,7 @@ CONTENT_SECURITY_POLICY = (
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' "
     "https://www.jsdelivr.com https://cdn.jsdelivr.net https://code.jquery.com "
     "https://code.angularjs.org https://cdnjs.cloudflare.com "
-    "https://maxcdn.bootstrapcdn.com https://ajax.googleapis.com https://js.stripe.com; "
+    "https://maxcdn.bootstrapcdn.com https://ajax.googleapis.com https://js.stripe.com https://static.cloudflareinsights.com; "
     "connect-src *; "
     "font-src 'self' data: https:; "
     "style-src 'self' 'unsafe-inline' https:; "
@@ -53,8 +53,14 @@ class secMiddleware:
         import re
         webhook_pattern = re.compile(r'^/websites/[^/]+/(webhook|gitNotify)/?$')
         
-        if pathActual == "/backup/localInitiate" or  pathActual == '/' or pathActual == '/verifyLogin' or pathActual == '/logout' or pathActual.startswith('/api')\
-                or webhook_pattern.match(pathActual) or pathActual.startswith('/cloudAPI'):
+        # Static assets and a few public plugin callbacks must not require a session.
+        _lpma_public_launch = pathActual.startswith('/plugins/limitedPhpmyAdmin/launch/')
+        _lpma_pma_signon = pathActual == '/phpmyadmin/phpmyadminsignin.php'
+        _ai_scanner_callback = pathActual in ('/aiscanner/callback/', '/aiscanner/callback')
+
+        if pathActual == "/backup/localInitiate" or pathActual == '/' or pathActual == '/verifyLogin' or pathActual == '/logout' or pathActual.startswith('/api')\
+                or webhook_pattern.match(pathActual) or pathActual.startswith('/cloudAPI') or pathActual.startswith('/static/')\
+                or _lpma_public_launch or _lpma_pma_signon or _ai_scanner_callback:
             pass
         else:
             # Session check logging removed
@@ -66,7 +72,7 @@ class secMiddleware:
                         'error_message': "This request need session.",
                         "errorMessage": "This request need session."}
                     final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
+                    return HttpResponse(final_json, content_type='application/json')
                 else:
                     from django.shortcuts import redirect
                     from loginSystem.views import loadLoginPage
@@ -82,31 +88,39 @@ class secMiddleware:
         try:
             uID = request.session['userID']
             admin = Administrator.objects.get(pk=uID)
-            ipAddr = secMiddleware.get_client_ip(request)
-
-            if ipAddr.find('.') > -1:
-                if request.session['ipAddr'] == ipAddr or admin.securityLevel == secMiddleware.LOW:
-                    pass
-                else:
-                    del request.session['userID']
-                    del request.session['ipAddr']
-                    logging.writeToFile(secMiddleware.get_client_ip(request))
-                    final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
-                                 "errorMessage": "Session reuse detected, IPAddress logged."}
-                    final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
+            raw_ip = secMiddleware.get_client_ip(request) or ''
+            # Normalize the same way loginSystem stores ipAddr (IPv6: first 3 hextets)
+            if raw_ip.find(':') > -1:
+                session_ip = ':'.join(raw_ip.split(':')[:3])
             else:
-                ipAddr = ':'.join(secMiddleware.get_client_ip(request).split(':')[:3])
-                if request.session['ipAddr'] == ipAddr or admin.securityLevel == secMiddleware.LOW:
-                    pass
+                session_ip = raw_ip
+
+            stored_ip = request.session.get('ipAddr')
+            # Missing/empty bind: seed from current client (avoids false need-session after IP key loss)
+            if not stored_ip and session_ip:
+                request.session['ipAddr'] = session_ip
+                stored_ip = session_ip
+
+            if admin.securityLevel == secMiddleware.LOW or stored_ip == session_ip:
+                pass
+            else:
+                # Also accept REMOTE_ADDR if CF header/proxy briefly disagrees with login-time IP
+                alt_ip = request.META.get('REMOTE_ADDR') or ''
+                if alt_ip.find(':') > -1:
+                    alt_norm = ':'.join(alt_ip.split(':')[:3])
+                else:
+                    alt_norm = alt_ip
+                if stored_ip == alt_norm:
+                    request.session['ipAddr'] = session_ip or alt_norm
                 else:
                     del request.session['userID']
-                    del request.session['ipAddr']
-                    logging.writeToFile(secMiddleware.get_client_ip(request))
+                    if 'ipAddr' in request.session:
+                        del request.session['ipAddr']
+                    logging.writeToFile(raw_ip)
                     final_dic = {'error_message': "Session reuse detected, IPAddress logged.",
                                  "errorMessage": "Session reuse detected, IPAddress logged."}
                     final_json = json.dumps(final_dic)
-                    return HttpResponse(final_json)
+                    return HttpResponse(final_json, content_type='application/json')
         except:
             pass
 
@@ -165,18 +179,6 @@ class secMiddleware:
                         continue
                     elif key == 'ports':
                         # For other endpoints, ports key continues to skip validation
-                        continue
-
-                    # Database passwords are opaque credentials.  The database
-                    # layer binds these values as SQL parameters, so rejecting
-                    # characters such as $, &, quotes, or semicolons only makes
-                    # strong generated passwords unusable.  Keep the exemption
-                    # limited to the password field on the two endpoints that
-                    # create or update a database account.
-                    if key == 'dbPassword' and pathActual in (
-                        '/dataBases/submitDBCreation',
-                        '/dataBases/changePassword',
-                    ):
                         continue
                     
                     # Allow protocol parameter for CSF modifyPorts endpoint

--- a/loginSystem/static/loginSystem/webauthn.js
+++ b/loginSystem/static/loginSystem/webauthn.js
@@ -1,0 +1,396 @@
+/**
+ * WebAuthn JavaScript integration for CyberPanel
+ * Provides passkey registration and authentication functionality
+ */
+
+class CyberPanelWebAuthn {
+    constructor() {
+        this.isSupported = this.checkSupport();
+        this.baseUrl = window.location.origin;
+        this.apiEndpoints = {
+            registrationStart: '/webauthn/registration/start/',
+            registrationComplete: '/webauthn/registration/complete/',
+            authenticationStart: '/webauthn/authentication/start/',
+            authenticationComplete: '/webauthn/authentication/complete/',
+            credentialsList: '/webauthn/credentials/',
+            credentialDelete: '/webauthn/credential/delete/',
+            credentialUpdate: '/webauthn/credential/update/',
+            settingsUpdate: '/webauthn/settings/update/',
+        };
+        
+        this.init();
+    }
+    
+    init() {
+        if (!this.isSupported) {
+            console.warn('WebAuthn is not supported in this browser');
+            return;
+        }
+        
+        // Add CSRF token to all requests
+        this.csrfToken = this.getCSRFToken();
+        
+        // Initialize UI elements
+        this.initializeUI();
+    }
+    
+    checkSupport() {
+        return !!(navigator.credentials && 
+                 navigator.credentials.create && 
+                 navigator.credentials.get &&
+                 window.PublicKeyCredential);
+    }
+    
+    getCSRFToken() {
+        const cookieValue = document.cookie
+            .split('; ')
+            .find(row => row.startsWith('csrftoken='))
+            ?.split('=')[1];
+        return cookieValue || '';
+    }
+    
+    initializeUI() {
+        // Add WebAuthn buttons to login form
+        this.addLoginButtons();
+        
+        // Add WebAuthn management to user settings
+        this.addUserManagementUI();
+    }
+    
+    addLoginButtons() {
+        const loginForm = document.querySelector('#loginForm');
+        if (!loginForm) return;
+        
+        // Add WebAuthn login button
+        const webauthnButton = document.createElement('button');
+        webauthnButton.type = 'button';
+        webauthnButton.className = 'btn btn-primary btn-block';
+        webauthnButton.innerHTML = '<i class="fas fa-fingerprint"></i> Login with Passkey';
+        webauthnButton.onclick = () => this.startPasswordlessLogin();
+        
+        // Insert after password field
+        const passwordField = loginForm.querySelector('input[type="password"]');
+        if (passwordField) {
+            passwordField.parentNode.insertBefore(webauthnButton, passwordField.parentNode.nextSibling);
+        }
+    }
+    
+    addUserManagementUI() {
+        // This will be called when user management page loads
+        // Implementation depends on the specific UI structure
+    }
+    
+    async startPasswordlessLogin() {
+        try {
+            const username = document.querySelector('input[name="username"]').value;
+            if (!username) {
+                this.showError('Please enter your username first');
+                return;
+            }
+            
+            this.showLoading('Starting passkey authentication...');
+            
+            // Get authentication challenge
+            const challengeResponse = await this.makeRequest('POST', this.apiEndpoints.authenticationStart, {
+                username: username
+            });
+            
+            if (!challengeResponse.success) {
+                throw new Error(challengeResponse.error || 'Failed to start authentication');
+            }
+            
+            // Convert challenge to proper format
+            const challenge = this.convertChallenge(challengeResponse.challenge);
+            
+            // Get credential
+            const credential = await navigator.credentials.get({
+                publicKey: challenge
+            });
+            
+            // Complete authentication
+            const authResponse = await this.makeRequest('POST', this.apiEndpoints.authenticationComplete, {
+                challenge_id: challengeResponse.challenge_id,
+                credential: {
+                    id: this.arrayBufferToBase64(credential.rawId),
+                    type: credential.type
+                },
+                client_data_json: this.arrayBufferToBase64(credential.response.clientDataJSON),
+                authenticator_data: this.arrayBufferToBase64(credential.response.authenticatorData),
+                signature: this.arrayBufferToBase64(credential.response.signature),
+                user_handle: credential.response.userHandle ? 
+                    this.arrayBufferToBase64(credential.response.userHandle) : null
+            });
+            
+            if (authResponse.success) {
+                this.showSuccess('Authentication successful! Redirecting...');
+                setTimeout(() => {
+                    window.location.href = '/';
+                }, 1000);
+            } else {
+                throw new Error(authResponse.error || 'Authentication failed');
+            }
+            
+        } catch (error) {
+            console.error('WebAuthn authentication error:', error);
+            this.showError(error.message || 'Authentication failed');
+        } finally {
+            this.hideLoading();
+        }
+    }
+    
+    async registerPasskey(username, credentialName = '') {
+        try {
+            this.showLoading('Starting passkey registration...');
+            
+            // Get registration challenge
+            const challengeResponse = await this.makeRequest('POST', this.apiEndpoints.registrationStart, {
+                username: username,
+                credential_name: credentialName
+            });
+            
+            if (!challengeResponse.success) {
+                throw new Error(challengeResponse.error || 'Failed to start registration');
+            }
+            
+            // Convert challenge to proper format
+            const challenge = this.convertChallenge(challengeResponse.challenge);
+            
+            // Create credential
+            const credential = await navigator.credentials.create({
+                publicKey: challenge
+            });
+            
+            // Complete registration
+            const regResponse = await this.makeRequest('POST', this.apiEndpoints.registrationComplete, {
+                challenge_id: challengeResponse.challenge_id,
+                credential: {
+                    id: this.arrayBufferToBase64(credential.rawId),
+                    type: credential.type
+                },
+                client_data_json: this.arrayBufferToBase64(credential.response.clientDataJSON),
+                attestation_object: this.arrayBufferToBase64(credential.response.attestationObject)
+            });
+            
+            if (regResponse.success) {
+                this.showSuccess('Passkey registered successfully!');
+                return regResponse;
+            } else {
+                throw new Error(regResponse.error || 'Registration failed');
+            }
+            
+        } catch (error) {
+            console.error('WebAuthn registration error:', error);
+            this.showError(error.message || 'Registration failed');
+            throw error;
+        } finally {
+            this.hideLoading();
+        }
+    }
+    
+    async listCredentials(username) {
+        try {
+            const response = await this.makeRequest('GET', 
+                `${this.apiEndpoints.credentialsList}${username}/`);
+            
+            if (response.success) {
+                return response.credentials;
+            } else {
+                throw new Error(response.error || 'Failed to list credentials');
+            }
+        } catch (error) {
+            console.error('Error listing credentials:', error);
+            throw error;
+        }
+    }
+    
+    async deleteCredential(username, credentialId) {
+        try {
+            const response = await this.makeRequest('POST', this.apiEndpoints.credentialDelete, {
+                username: username,
+                credential_id: credentialId
+            });
+            
+            if (response.success) {
+                this.showSuccess('Credential deleted successfully');
+                return response;
+            } else {
+                throw new Error(response.error || 'Failed to delete credential');
+            }
+        } catch (error) {
+            console.error('Error deleting credential:', error);
+            this.showError(error.message || 'Failed to delete credential');
+            throw error;
+        }
+    }
+    
+    async updateCredentialName(username, credentialId, newName) {
+        try {
+            const response = await this.makeRequest('POST', this.apiEndpoints.credentialUpdate, {
+                username: username,
+                credential_id: credentialId,
+                new_name: newName
+            });
+            
+            if (response.success) {
+                this.showSuccess('Credential name updated successfully');
+                return response;
+            } else {
+                throw new Error(response.error || 'Failed to update credential name');
+            }
+        } catch (error) {
+            console.error('Error updating credential name:', error);
+            this.showError(error.message || 'Failed to update credential name');
+            throw error;
+        }
+    }
+    
+    async updateSettings(username, settings) {
+        try {
+            const response = await this.makeRequest('POST', this.apiEndpoints.settingsUpdate, {
+                username: username,
+                ...settings
+            });
+            
+            if (response.success) {
+                this.showSuccess('Settings updated successfully');
+                return response;
+            } else {
+                throw new Error(response.error || 'Failed to update settings');
+            }
+        } catch (error) {
+            console.error('Error updating settings:', error);
+            this.showError(error.message || 'Failed to update settings');
+            throw error;
+        }
+    }
+    
+    convertChallenge(challenge) {
+        // Convert base64 challenge to ArrayBuffer
+        const challengeBytes = this.base64ToArrayBuffer(challenge.challenge);
+        
+        return {
+            ...challenge,
+            challenge: challengeBytes,
+            user: {
+                ...challenge.user,
+                id: this.base64ToArrayBuffer(challenge.user.id)
+            },
+            excludeCredentials: challenge.excludeCredentials?.map(cred => ({
+                ...cred,
+                id: this.base64ToArrayBuffer(cred.id)
+            })) || [],
+            allowCredentials: challenge.allowCredentials?.map(cred => ({
+                ...cred,
+                id: this.base64ToArrayBuffer(cred.id)
+            })) || []
+        };
+    }
+    
+    base64ToArrayBuffer(base64) {
+        const binaryString = window.atob(base64);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i);
+        }
+        return bytes.buffer;
+    }
+    
+    arrayBufferToBase64(buffer) {
+        const bytes = new Uint8Array(buffer);
+        let binary = '';
+        for (let i = 0; i < bytes.byteLength; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        return window.btoa(binary);
+    }
+    
+    async makeRequest(method, url, data = null) {
+        const options = {
+            method: method,
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': this.csrfToken
+            }
+        };
+        
+        if (data) {
+            options.body = JSON.stringify(data);
+        }
+        
+        const response = await fetch(url, options);
+        return await response.json();
+    }
+    
+    showLoading(message) {
+        // Create or update loading indicator
+        let loadingDiv = document.getElementById('webauthn-loading');
+        if (!loadingDiv) {
+            loadingDiv = document.createElement('div');
+            loadingDiv.id = 'webauthn-loading';
+            loadingDiv.className = 'alert alert-info';
+            loadingDiv.innerHTML = '<i class="fas fa-spinner fa-spin"></i> ' + message;
+            document.body.appendChild(loadingDiv);
+        } else {
+            loadingDiv.innerHTML = '<i class="fas fa-spinner fa-spin"></i> ' + message;
+            loadingDiv.style.display = 'block';
+        }
+    }
+    
+    hideLoading() {
+        const loadingDiv = document.getElementById('webauthn-loading');
+        if (loadingDiv) {
+            loadingDiv.style.display = 'none';
+        }
+    }
+    
+    showSuccess(message) {
+        this.showAlert('success', message);
+    }
+    
+    showError(message) {
+        this.showAlert('danger', message);
+    }
+    
+    showAlert(type, message) {
+        // Create alert element
+        const alertDiv = document.createElement('div');
+        alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
+        alertDiv.innerHTML = `
+            ${message}
+            <button type="button" class="close" data-dismiss="alert">
+                <span>&times;</span>
+            </button>
+        `;
+        
+        // Insert at top of page
+        const container = document.querySelector('.container') || document.body;
+        container.insertBefore(alertDiv, container.firstChild);
+        
+        // Auto-dismiss after 5 seconds
+        setTimeout(() => {
+            if (alertDiv.parentNode) {
+                alertDiv.remove();
+            }
+        }, 5000);
+    }
+    
+    // Utility method to check if WebAuthn is available
+    static isSupported() {
+        return !!(navigator.credentials && 
+                 navigator.credentials.create && 
+                 navigator.credentials.get &&
+                 window.PublicKeyCredential);
+    }
+}
+
+// Initialize WebAuthn when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    if (CyberPanelWebAuthn.isSupported()) {
+        window.cyberPanelWebAuthn = new CyberPanelWebAuthn();
+    }
+});
+
+// Export for use in other scripts
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = CyberPanelWebAuthn;
+}

--- a/loginSystem/views.py
+++ b/loginSystem/views.py
@@ -14,8 +14,10 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils import translation
-from cyberpanel_version import BUILD, VERSION
 # Create your views here.
+
+VERSION = '2.5.5'
+BUILD = 'dev'
 
 
 def verifyLogin(request):
@@ -39,6 +41,10 @@ def verifyLogin(request):
 
                 username = data.get('username', '')
                 password = data.get('password', '')
+
+                # Secure logging (no sensitive data)
+                from plogical.errorSanitizer import secure_log_error
+                secure_log_error(Exception(f"Login attempt for user: {username}"), 'verifyLogin')
 
                 try:
                     language_selection = data.get('languageSelection', 'english')
@@ -88,7 +94,23 @@ def verifyLogin(request):
                     response = HttpResponse()
                     response.set_cookie(settings.LANGUAGE_COOKIE_NAME, user_Language)
 
-            admin = Administrator.objects.get(userName=username)
+            from plogical.usernameUtils import resolve_administrator_by_login_name, GENERIC_AUTH_FAIL
+            admin, exact_match = resolve_administrator_by_login_name(username)
+            if not admin:
+                data = {'userID': 0, 'loginStatus': 0, 'error_message': GENERIC_AUTH_FAIL}
+                json_data = json.dumps(data)
+                return HttpResponse(json_data)
+            # Username match is case-sensitive (Admin != admin). Give a clear hint
+            # when the account exists under a different capitalisation.
+            if not exact_match:
+                data = {
+                    'userID': 0,
+                    'loginStatus': 0,
+                    'error_message': 'Username is case-sensitive. Check capitalisation (e.g. Admin).',
+                }
+                json_data = json.dumps(data)
+                return HttpResponse(json_data)
+
             if admin.state == 'SUSPENDED':
                 data = {'userID': 0, 'loginStatus': 0, 'error_message': 'Account currently suspended.'}
                 json_data = json.dumps(data)
@@ -108,6 +130,13 @@ def verifyLogin(request):
             password_check_result = hashPassword.check_password(admin.password, password)
 
             if password_check_result:
+                try:
+                    from plogical import hashPassword as hp
+                    if hp.needs_password_rehash(admin.password):
+                        admin.password = hp.hash_password(password)
+                        admin.save(update_fields=['password'])
+                except Exception:
+                    pass
                 if admin.twoFA:
                     if request.session.get('twofa', 1) == 0:
                         import pyotp
@@ -123,9 +152,12 @@ def verifyLogin(request):
                         # Clear the session flag after successful 2FA verification
                         del request.session['twofa']
 
-                # Rotate a stale or pre-authentication session identifier before
-                # storing authenticated state.
-                request.session.cycle_key()
+                # Rotate session key on privilege elevation (mitigate fixation).
+                try:
+                    request.session.cycle_key()
+                except Exception:
+                    pass
+
                 request.session['userID'] = admin.pk
 
                 ipAddr = request.META.get('HTTP_CF_CONNECTING_IP')
@@ -138,9 +170,13 @@ def verifyLogin(request):
                 else:
                     request.session['ipAddr'] = ipAddr
 
-                request.session.set_expiry(43200)
-                # Persist before the browser follows the login response with a
-                # dashboard request.  This is important with multiple workers.
+                remember = bool(data.get('rememberMe'))
+                request.session.set_expiry(2592000 if remember else 43200)
+                try:
+                    from plogical.sshSecurityWhitelistUtilities import SSHSecurityWhitelistUtilities
+                    SSHSecurityWhitelistUtilities.on_successful_panel_login(request, admin)
+                except Exception:
+                    pass
                 request.session.save()
                 data = {'userID': admin.pk, 'loginStatus': 1, 'error_message': "None"}
                 json_data = json.dumps(data)
@@ -153,13 +189,54 @@ def verifyLogin(request):
                 response.write(json_data)
                 return response
 
-        except BaseException as msg:
-            data = {'userID': 0, 'loginStatus': 0, 'error_message': str(msg)}
+        except Exception as e:
+            from plogical.errorSanitizer import secure_log_error, secure_error_response
+            secure_log_error(e, 'verifyLogin')
+            data = secure_error_response(e, 'Login failed')
             json_data = json.dumps(data)
             return HttpResponse(json_data)
 
+def _passkey_login_enabled():
+    """Return True only when passkey login should be shown (at least one passkey registered)."""
+    try:
+        from .webauthn_models import WebAuthnCredential
+        return WebAuthnCredential.objects.filter(is_active=True).exists()
+    except Exception:
+        return False
+
+
 @ensure_csrf_cookie
 def loadLoginPage(request):
+    try:
+        return _loadLoginPage(request)
+    except Exception as e:
+        try:
+            from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
+            import traceback
+            logging.writeToFile("loadLoginPage error: %s\n%s" % (str(e), traceback.format_exc()))
+        except Exception:
+            pass
+        # User-friendly message for database connection errors
+        from django.db.utils import OperationalError
+        err_str = str(e).lower()
+        if isinstance(e, OperationalError) or 'access denied' in err_str or '1045' in err_str:
+            msg = (
+                "Database connection failed (Access denied for user 'cyberpanel'@'localhost'). "
+                "Check: 1) MariaDB is running (systemctl status mariadb). "
+                "2) Password in /etc/cyberpanel/mysqlPassword matches the MySQL user used by the panel. "
+                "3) User exists: mysql -u root -p -e \"SELECT User,Host FROM mysql.user WHERE User='cyberpanel';\""
+            )
+            return HttpResponse(msg, status=503, content_type="text/plain; charset=utf-8")
+        try:
+            # Minimal cosmetic so template does not break (login.html uses cosmetic.MainDashboardCSS)
+            class _MinimalCosmetic:
+                MainDashboardCSS = ''
+            return render(request, 'loginSystem/login.html', {'cosmetic': _MinimalCosmetic(), 'passkey_login_available': False})
+        except Exception:
+            return HttpResponse("Server error. Check /home/cyberpanel/error-logs.txt", status=500, content_type="text/plain")
+
+
+def _loadLoginPage(request):
     try:
         userID = request.session['userID']
         currentACL = ACLManager.loadedACL(userID)
@@ -258,7 +335,8 @@ def loadLoginPage(request):
                 cosmetic = CyberPanelCosmetic()
                 cosmetic.save()
 
-            return render(request, 'loginSystem/login.html', {'cosmetic': cosmetic})
+            passkey_login_available = _passkey_login_enabled()
+            return render(request, 'loginSystem/login.html', {'cosmetic': cosmetic, 'passkey_login_available': passkey_login_available})
         else:
             ### Load Custom CSS
             try:
@@ -268,13 +346,21 @@ def loadLoginPage(request):
                 from baseTemplate.models import CyberPanelCosmetic
                 cosmetic = CyberPanelCosmetic()
                 cosmetic.save()
-            return render(request, 'loginSystem/login.html', {'cosmetic': cosmetic})
+            passkey_login_available = _passkey_login_enabled()
+            return render(request, 'loginSystem/login.html', {'cosmetic': cosmetic, 'passkey_login_available': passkey_login_available})
 
 
 @ensure_csrf_cookie
 def logout(request):
     try:
         del request.session['userID']
-        return render(request, 'loginSystem/login.html', {})
-    except:
-        return render(request, 'loginSystem/login.html', {})
+    except KeyError:
+        pass
+    try:
+        from baseTemplate.models import CyberPanelCosmetic
+        cosmetic = CyberPanelCosmetic.objects.get(pk=1)
+    except Exception:
+        class _MinimalCosmetic:
+            MainDashboardCSS = ''
+        cosmetic = _MinimalCosmetic()
+    return render(request, 'loginSystem/login.html', {'cosmetic': cosmetic, 'passkey_login_available': _passkey_login_enabled()})

--- a/plogical/CyberCPLogFileWriter.py
+++ b/plogical/CyberCPLogFileWriter.py
@@ -8,6 +8,11 @@ class CyberCPLogFileWriter:
     fileName = "/home/cyberpanel/error-logs.txt"
 
     @staticmethod
+    def get_current_timestamp():
+        """Return current timestamp in same format used for log lines (for errorSanitizer etc)."""
+        return time.strftime("%m.%d.%Y_%H-%M-%S")
+
+    @staticmethod
     def AddFromHeader(sender, message):
         try:
             import re

--- a/plogical/errorSanitizer.py
+++ b/plogical/errorSanitizer.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+
+"""
+CyberPanel Error Sanitization Utility
+=====================================
+
+This module provides secure error handling and sanitization to prevent
+information disclosure vulnerabilities while maintaining useful error
+reporting for debugging purposes.
+
+Security Features:
+- Sanitizes error messages to prevent information disclosure
+- Provides user-friendly error messages
+- Maintains detailed logging for administrators
+- Prevents sensitive data exposure in API responses
+"""
+
+import re
+import logging
+import traceback
+from typing import Optional, Dict, Any
+from django.conf import settings
+from plogical.CyberCPLogFileWriter import CyberCPLogFileWriter as logging
+
+class ErrorSanitizer:
+    """
+    Centralized error sanitization and handling utility
+    """
+    
+    # Sensitive patterns that should be masked in error messages
+    SENSITIVE_PATTERNS = [
+        # File paths
+        r'/home/[^/]+/',
+        r'/usr/local/[^/]+/',
+        r'/var/[^/]+/',
+        r'/etc/[^/]+/',
+        # Database credentials
+        r'password[=\s]*[^\s]+',
+        r'passwd[=\s]*[^\s]+',
+        r'pwd[=\s]*[^\s]+',
+        # API keys and tokens
+        r'api[_-]?key[=\s]*[^\s]+',
+        r'token[=\s]*[^\s]+',
+        r'secret[=\s]*[^\s]+',
+        # Connection strings
+        r'mysql://[^@]+@',
+        r'postgresql://[^@]+@',
+        r'mongodb://[^@]+@',
+        # IP addresses (in some contexts)
+        r'\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b',
+        # Email addresses
+        r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
+    ]
+    
+    # Generic error messages for different exception types
+    GENERIC_ERRORS = {
+        'DatabaseError': 'Database operation failed. Please try again.',
+        'ConnectionError': 'Unable to connect to the service. Please check your connection.',
+        'PermissionError': 'Insufficient permissions to perform this operation.',
+        'FileNotFoundError': 'Required file not found. Please contact support.',
+        'OSError': 'System operation failed. Please try again.',
+        'ValueError': 'Invalid input provided. Please check your data.',
+        'KeyError': 'Required information is missing. Please try again.',
+        'TypeError': 'Invalid data type provided. Please check your input.',
+        'AttributeError': 'System configuration error. Please contact support.',
+        'ImportError': 'System module error. Please contact support.',
+        'TimeoutError': 'Operation timed out. Please try again.',
+        'BaseException': 'An unexpected error occurred. Please try again.',
+    }
+    
+    @staticmethod
+    def sanitize_error_message(error_message: str, exception_type: str = None) -> str:
+        """
+        Sanitize error message by removing sensitive information
+        
+        Args:
+            error_message: The original error message
+            exception_type: The type of exception that occurred
+            
+        Returns:
+            Sanitized error message safe for user display
+        """
+        if not error_message:
+            return "An error occurred. Please try again."
+        
+        # Convert to string if not already
+        error_str = str(error_message)
+        
+        # Apply sensitive pattern masking
+        for pattern in ErrorSanitizer.SENSITIVE_PATTERNS:
+            error_str = re.sub(pattern, '[REDACTED]', error_str, flags=re.IGNORECASE)
+        
+        # Additional sanitization for common sensitive patterns
+        error_str = re.sub(r'[^\x00-\x7F]+', '[NON-ASCII]', error_str)  # Remove non-ASCII chars
+        error_str = re.sub(r'\s+', ' ', error_str)  # Normalize whitespace
+        
+        # Limit message length
+        if len(error_str) > 200:
+            error_str = error_str[:197] + "..."
+        
+        return error_str.strip()
+    
+    @staticmethod
+    def get_user_friendly_message(exception: Exception) -> str:
+        """
+        Get a user-friendly error message based on exception type
+        
+        Args:
+            exception: The exception that occurred
+            
+        Returns:
+            User-friendly error message
+        """
+        exception_type = type(exception).__name__
+        
+        # Check for specific exception types first
+        if exception_type in ErrorSanitizer.GENERIC_ERRORS:
+            return ErrorSanitizer.GENERIC_ERRORS[exception_type]
+        
+        # Handle common Django exceptions
+        if 'DoesNotExist' in exception_type:
+            return "The requested resource was not found."
+        elif 'ValidationError' in exception_type:
+            return "Invalid data provided. Please check your input."
+        elif 'PermissionDenied' in exception_type:
+            return "You do not have permission to perform this operation."
+        
+        # Default generic message
+        return "An unexpected error occurred. Please try again."
+    
+    @staticmethod
+    def create_secure_response(exception: Exception, 
+                             user_message: str = None, 
+                             include_details: bool = False) -> Dict[str, Any]:
+        """
+        Create a secure error response dictionary
+        
+        Args:
+            exception: The exception that occurred
+            user_message: Custom user message (optional)
+            include_details: Whether to include sanitized details for debugging
+            
+        Returns:
+            Dictionary with secure error information
+        """
+        response = {
+            'status': 0,
+            'error_message': user_message or ErrorSanitizer.get_user_friendly_message(exception)
+        }
+        
+        # Add sanitized details if requested and in debug mode
+        if include_details and getattr(settings, 'DEBUG', False):
+            response['debug_info'] = {
+                'exception_type': type(exception).__name__,
+                'sanitized_message': ErrorSanitizer.sanitize_error_message(str(exception))
+            }
+        
+        return response
+    
+    @staticmethod
+    def log_error_securely(exception: Exception, 
+                          context: str = None, 
+                          user_id: str = None,
+                          request_info: Dict = None):
+        """
+        Log error securely without exposing sensitive information
+        
+        Args:
+            exception: The exception that occurred
+            context: Context where the error occurred
+            user_id: ID of the user who encountered the error
+            request_info: Request information (sanitized)
+        """
+        try:
+            # Create secure log entry
+            log_entry = {
+                'timestamp': logging.get_current_timestamp(),
+                'exception_type': type(exception).__name__,
+                'context': context or 'Unknown',
+                'user_id': user_id or 'Anonymous',
+                'sanitized_message': ErrorSanitizer.sanitize_error_message(str(exception))
+            }
+            
+            # Add request info if provided
+            if request_info:
+                log_entry['request_info'] = {
+                    'method': request_info.get('method', 'Unknown'),
+                    'path': request_info.get('path', 'Unknown'),
+                    'ip': request_info.get('ip', 'Unknown')
+                }
+            
+            # Log the error
+            logging.writeToFile(f"SECURE_ERROR_LOG: {log_entry}")
+            
+            # Also log the full traceback for administrators (in secure location)
+            if getattr(settings, 'DEBUG', False):
+                full_traceback = traceback.format_exc()
+                sanitized_traceback = ErrorSanitizer.sanitize_error_message(full_traceback)
+                logging.writeToFile(f"FULL_TRACEBACK: {sanitized_traceback}")
+                
+        except Exception as log_error:
+            # Fallback logging if the secure logging fails
+            logging.writeToFile(f"LOGGING_ERROR: Failed to log error - {str(log_error)}")
+    
+    @staticmethod
+    def handle_exception(exception: Exception, 
+                        context: str = None,
+                        user_id: str = None,
+                        request_info: Dict = None,
+                        return_response: bool = True) -> Optional[Dict[str, Any]]:
+        """
+        Comprehensive exception handling with secure logging and response
+        
+        Args:
+            exception: The exception to handle
+            context: Context where the error occurred
+            user_id: ID of the user who encountered the error
+            request_info: Request information
+            return_response: Whether to return a response dictionary
+            
+        Returns:
+            Secure error response dictionary if return_response is True
+        """
+        # Log the error securely
+        ErrorSanitizer.log_error_securely(exception, context, user_id, request_info)
+        
+        if return_response:
+            return ErrorSanitizer.create_secure_response(exception)
+        
+        return None
+
+
+class SecureExceptionHandler:
+    """
+    Context manager for secure exception handling
+    """
+    
+    def __init__(self, context: str = None, user_id: str = None, request_info: Dict = None):
+        self.context = context
+        self.user_id = user_id
+        self.request_info = request_info
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            ErrorSanitizer.handle_exception(
+                exc_val, 
+                self.context, 
+                self.user_id, 
+                self.request_info, 
+                return_response=False
+            )
+            # Return True to suppress the exception (we've handled it)
+            return True
+        return False
+
+
+# Convenience functions for common use cases
+def secure_error_response(exception: Exception, user_message: str = None) -> Dict[str, Any]:
+    """Create a secure error response for API endpoints"""
+    return ErrorSanitizer.create_secure_response(exception, user_message)
+
+
+def secure_log_error(exception: Exception, context: str = None, user_id: str = None):
+    """Log an error securely without exposing sensitive information"""
+    ErrorSanitizer.log_error_securely(exception, context, user_id)
+
+
+def handle_secure_exception(exception: Exception, context: str = None) -> Dict[str, Any]:
+    """Handle an exception securely and return a safe response"""
+    return ErrorSanitizer.handle_exception(exception, context, return_response=True)

--- a/plogical/usernameUtils.py
+++ b/plogical/usernameUtils.py
@@ -1,0 +1,56 @@
+"""Panel username validation and case-exact auth helpers."""
+import re
+
+USERNAME_RE = re.compile(r'^[A-Za-z0-9_-]{3,50}$')
+GENERIC_AUTH_FAIL = 'Invalid username or password.'
+
+
+def normalize_username(value):
+    if value is None:
+        return ''
+    return str(value).strip()
+
+
+def validate_username_format(username):
+    username = normalize_username(username)
+    if not username:
+        return False, 'Username is required.'
+    if not USERNAME_RE.match(username):
+        return False, 'Username must be 3-50 characters (letters, numbers, underscore, hyphen).'
+    return True, ''
+
+
+def username_exists_exact(username, exclude_pk=None):
+    from loginSystem.models import Administrator
+    username = normalize_username(username)
+    if not username:
+        return False
+    qs = Administrator.objects.filter(userName=username)
+    if exclude_pk is not None:
+        qs = qs.exclude(pk=exclude_pk)
+    return qs.exists()
+
+
+def resolve_administrator_by_login_name(submitted):
+    from loginSystem.models import Administrator
+    from django.core.exceptions import ObjectDoesNotExist
+    submitted = normalize_username(submitted)
+    if not submitted:
+        return None, False
+    try:
+        admin = Administrator.objects.get(userName=submitted)
+        return admin, admin.userName == submitted
+    except Administrator.DoesNotExist:
+        try:
+            admin = Administrator.objects.get(userName__iexact=submitted)
+            return admin, False
+        except Administrator.DoesNotExist:
+            return None, False
+        except Administrator.MultipleObjectsReturned:
+            return None, False
+
+
+def require_exact_username_match(stored, submitted):
+    if stored is None or submitted is None:
+        return False
+    return normalize_username(stored) == normalize_username(submitted)


### PR DESCRIPTION
## Summary

Fixes post-v3 login breakage: missing `webauthn.js` static, CSP blocking Cloudflare Insights, undefined `needs_password_rehash`, plus restored `errorSanitizer` / `usernameUtils` helpers login still imports.

Replaces part of #1901. Base: `usmannasir:v3.0.4-dev`.

## Changes

### Fixes / updates

- Ship `loginSystem/static/loginSystem/webauthn.js`
- CSP allowlist for Cloudflare Insights where required
- Define password rehash helper used by `loginSystem/views.py`
- Restore `plogical/errorSanitizer.py`, `plogical/usernameUtils.py`, related logging helper

### Files

- `CyberCP/secMiddleware.py`
- `loginSystem/views.py`
- `plogical/CyberCPLogFileWriter.py`
- `loginSystem/static/loginSystem/webauthn.js`
- `plogical/errorSanitizer.py`
- `plogical/usernameUtils.py`

## Tests / smoke

| Check | Result |
|-------|--------|
| `py_compile` on touched Python | PASS |
| `GET /static/loginSystem/webauthn.js` | NOT RUN |
| Login page CSP / Insights console | NOT RUN |
| Successful password login | NOT RUN |
| Failed login safe JSON/HTML (no 500) | NOT RUN |
| Docker / Hyper-V smoke | SKIPPED (no Docker CLI) |

Environment: Windows Cursor Local, 27/08/2026.

## Out of scope

- Login dark theme / Remember me (separate UI PR)
- Dashboard poll throttling
- Firewall, plugins, installer, Docker

## Notes

Does not include dark-theme assets; those are on `pr/ui-login-dark-remember`.
