### PR TITLE
feat(install): EL10-friendly installer repo/branch and admin username

### DIFF
--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -137,6 +137,11 @@ log_info "Fetching latest data from CyberPanel server"
 Silent="Off"
 Server_Edition="OLS"
 Admin_Pass="1234567"
+Admin_User="${CYBERPANEL_ADMIN_USER:-admin}"
+
+if [[ -n "${CYBERPANEL_GIT_USER:-}" ]]; then
+  Git_User_Override="${CYBERPANEL_GIT_USER}"
+fi
 
 Memcached="Off"
 Redis="Off"
@@ -165,7 +170,10 @@ parse_panel_version() {
 }
 
 Temp_Value=$(curl --silent --max-time 30 -4 https://cyberpanel.net/version.txt)
-if parse_panel_version "$Temp_Value"; then
+if [[ -n "${CYBERPANEL_BRANCH:-}" ]]; then
+  Branch_Check "${CYBERPANEL_BRANCH}"
+  echo -e  "\nBranch name set from CYBERPANEL_BRANCH...$Branch_Name"
+elif parse_panel_version "$Temp_Value"; then
   Branch_Name="v${Panel_Version}.${Panel_Build}"
   echo -e  "\nBranch name fetched...$Branch_Name"
   log_info "Branch name fetched: $Branch_Name"
@@ -186,6 +194,7 @@ Remote_MySQL="Off"
 Final_Flags=()
 
 Git_User=""
+Git_User_Override=""
 Git_Content_URL=""
 Git_Clone_URL=""
 
@@ -441,24 +450,30 @@ Validate_Remote_MySQL() {
 }
 
 Branch_Check() {
-if [[ "$1" = *.*.* ]]; then
-  #check input if it's valid format as X.Y.Z
-  Output=$(awk -v num1="$Base_Number" -v num2="${1//[[:space:]]/}" '
-  BEGIN {
-    print "num1", (num1 < num2 ? "<" : ">="), "num2"
-  }
-  ')
-  if [[ $Output = *">="* ]]; then
-    echo -e "\nYou must use version number higher than 1.9.4"
-    exit
-  else
-    Branch_Name="v${1//[[:space:]]/}"
-    echo -e "\nSet branch name to $Branch_Name..."
-  fi
+local raw="${1//[[:space:]]/}"
+if [[ "$raw" == v*.*.* ]]; then
+  Branch_Name="$raw"
+elif [[ "$raw" == *.*.* ]]; then
+  Branch_Name="v${raw}"
 else
-  echo -e "\nPlease input a valid format version number."
+  echo -e "
+Please input a valid format version number (for example 3.0.4 or 3.0.4-dev)."
   exit
 fi
+local cmp="${Branch_Name#v}"
+cmp="${cmp%%-*}"
+Output=$(awk -v num1="$Base_Number" -v num2="$cmp" '
+BEGIN {
+  print "num1", (num1 < num2 ? "<" : ">="), "num2"
+}
+')
+if [[ $Output = *">="* ]]; then
+  echo -e "
+You must use version number higher than 1.9.4"
+  exit
+fi
+echo -e "
+Set branch name to $Branch_Name..."
 }
 
 License_Check() {
@@ -788,6 +803,9 @@ echo -e "\n\e[31m-m postfix/pureftpd/powerdns\e[39m will do minimal install also
 echo -e "e.g.  \e[31m-m postfix\e[39m will do minimal install also with Postfix"
 echo -e "      \e[31m-m powerdns\e[39m will do minimal install also with PowerDNS"
 echo -e "      \e[31m-m postfix\e[39m powerdns will do minimal install also with Postfix and PowerDNS"
+echo -e "\n\e[31m-u\e[39m or \e[31m--username\e[39m : panel admin username (default admin, 3-32 chars)"
+echo -e "\n\e[31m-r\e[39m or \e[31m--repo\e[39m : GitHub user that owns the cyberpanel repo (default usmannasir, fork: master3395)"
+echo -e "e.g.  \e[31m--repo master3395\e[39m clones github.com/master3395/cyberpanel"
 echo -e "\n\e[31m-b\e[39m or \e[31m--branch\e[39m : install with given branch/version , must be higher than 1.9.4"
 echo -e "e.g.  \e[31m-b 2.0.2\e[39m will install 2.0.2 version"
 echo -e "\n\e[31m--mirror\e[39m : this argument force to use mirror server for majority of repositories, only suggest to use for servers within China"
@@ -860,6 +878,28 @@ else
       shift
         Branch_Check "${1}"
       ;;
+      -r | --repo)
+      shift
+      if [[ "${1}" = "" ]]; then
+        Show_Help
+        exit
+      fi
+      Git_User_Override="${1}"
+      echo -e "\nUsing --repo: GitHub user ${Git_User_Override} for cyberpanel..."
+      ;;
+      -u | --username)
+      shift
+      if [[ "${1}" = "" ]]; then
+        Show_Help
+        exit
+      fi
+      if [[ ! "${1}" =~ ^[A-Za-z0-9_]{3,32}$ ]]; then
+        echo -e "\nInvalid username. Use 3-32 characters: letters, numbers, underscore.\n"
+        exit
+      fi
+      Admin_User="${1}"
+      echo -e "\nSet admin username to ${Admin_User}..."
+      ;;
       -m | --minimal)
       if ! echo "$@" | grep -q -i "postfix\|pureftpd\|powerdns" ; then
         Postfix_Switch="Off"
@@ -918,6 +958,58 @@ fi
 
 Debug_Log2 "Initialization completed..,2"
 }
+
+Apply_Container_Env() {
+log_function_start "Apply_Container_Env"
+if [[ -f /run/.containerenv ]] || [[ "${CYBERPANEL_CONTAINER:-0}" = "1" ]]; then
+  export CYBERPANEL_CONTAINER=1
+  Silent="On"
+  Server_Edition="OLS"
+  Memcached="Off"
+  Redis="Off"
+  Watchdog="On"
+
+  if [[ "${CYBERPANEL_FULL_INSTALL:-0}" = "1" ]]; then
+    CYBERPANEL_MINIMAL=0
+    Postfix_Switch="On"
+    PowerDNS_Switch="On"
+    PureFTPd_Switch="On"
+    log_info "Container full install mode (CYBERPANEL_FULL_INSTALL=1)"
+  elif [[ "${CYBERPANEL_MINIMAL:-0}" = "1" ]]; then
+    Postfix_Switch="Off"
+    PowerDNS_Switch="Off"
+    PureFTPd_Switch="Off"
+    if [[ "${CYBERPANEL_ENABLE_POSTFIX:-0}" = "1" ]]; then Postfix_Switch="On"; fi
+    if [[ "${CYBERPANEL_ENABLE_POWERDNS:-0}" = "1" ]]; then PowerDNS_Switch="On"; fi
+    if [[ "${CYBERPANEL_ENABLE_PUREFTPD:-0}" = "1" ]]; then PureFTPd_Switch="On"; fi
+    log_info "Container minimal/partial mode (CYBERPANEL_MINIMAL=1)"
+  fi
+
+  if [[ -n "${CYBERPANEL_ADMIN_PASSWORD:-}" ]]; then
+    Admin_Pass="${CYBERPANEL_ADMIN_PASSWORD}"
+  fi
+  if [[ -n "${CYBERPANEL_ADMIN_USER:-}" ]]; then
+    Admin_User="${CYBERPANEL_ADMIN_USER}"
+  fi
+  if [[ -n "${CYBERPANEL_BRANCH:-}" ]]; then
+    Branch_Name="${CYBERPANEL_BRANCH}"
+  fi
+  if [[ -n "${CYBERPANEL_REPO:-}" ]]; then
+    Git_User_Override="${CYBERPANEL_REPO}"
+  fi
+  if [[ -z "${Server_IP:-}" ]] || [[ "${Server_IP}" = "" ]]; then
+    Server_IP=$(curl -s --max-time 10 -4 ifconfig.me 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')
+    Server_IP="${Server_IP:-127.0.0.1}"
+  fi
+  if [[ -n "${CYBERPANEL_HOSTNAME:-}" ]]; then
+    hostnamectl set-hostname "${CYBERPANEL_HOSTNAME}" 2>/dev/null || hostname "${CYBERPANEL_HOSTNAME}" 2>/dev/null || true
+  fi
+  log_info "Container runtime detected; silent install enabled"
+fi
+log_function_end "Apply_Container_Env"
+}
+
+
 
 Argument_Mode() {
 if [[ "${Server_Edition^^}" = "OLS" ]] ; then
@@ -1079,9 +1171,22 @@ else
   Branch_Check "$Tmp_Input"
 fi
 
+echo -e "\nChoose panel admin username (default: admin, 3-32 chars, letters/numbers/underscore):"
+printf "%s" "Username [admin]: "
+read -r Tmp_Input
+if [[ -z "$Tmp_Input" ]]; then
+  Admin_User="admin"
+elif [[ "$Tmp_Input" =~ ^[A-Za-z0-9_]{3,32}$ ]]; then
+  Admin_User="$Tmp_Input"
+else
+  echo -e "\nInvalid username. Use 3-32 characters: letters, numbers, underscore.\n"
+  exit
+fi
+echo -e "\nAdmin username will be set to $Admin_User\n"
+
 echo -e "\nPlease choose to use default admin password \e[31m1234567\e[39m, randomly generate one \e[31m(recommended)\e[39m or specify the admin password?"
 printf "%s" "Choose [d]fault, [r]andom or [s]et password: [d/r/s] "
-Tmp_Input="r"
+read -r Tmp_Input
 
 if [[ $Tmp_Input =~ ^(d|D| ) ]] || [[ -z $Tmp_Input ]]; then
   Admin_Pass="1234567"
@@ -1979,10 +2084,17 @@ if [[ "$Remote_MySQL" = "On" ]] ; then
 else
   Final_Flags+=(--remotemysql "${Remote_MySQL^^}")
 fi
+
+if [[ "${CYBERPANEL_CONTAINER:-0}" = "1" ]]; then
+  Final_Flags+=(--container ON)
+fi
   #form up the final agurment for install.py
 if [[ "$Debug" = "On" ]] ; then
   Debug_Log "Final_Flags" "${Final_Flags[@]}"
 fi
+
+export CYBERPANEL_BRANCH="${Branch_Name:-stable}"
+export CYBERPANEL_GIT_USER="${Git_User:-usmannasir}"
 
 if [[ "$Remote_MySQL" = "On" ]] ; then
   CP_INSTALL_MYSQL_PASSWORD="$MySQL_Password" \
@@ -2213,7 +2325,7 @@ echo "                                                                   "
 echo "                Installation time  : $Elapsed_Time                 "
 echo "                                                                   "
 echo "                Visit: https://$Server_IP:8090                     "
-echo "                Panel username: admin                              "
+echo "                Panel username: $Admin_User                              "
 if [[ "$Custom_Pass" = "True" ]]; then
 echo "                Panel password: *****                              "
 else
@@ -2499,11 +2611,20 @@ chown -R cyberpanel:cyberpanel /usr/local/CyberCP/lib64 || true
 
 Pre_Install_Setup_Git_URL() {
 if [[ $Server_Country != "CN" ]] ; then
-  Git_User="usmannasir"
+  if [[ -n "$Git_User_Override" ]]; then
+    Git_User="$Git_User_Override"
+    echo -e "\nUsing GitHub repo: ${Git_User}/cyberpanel\n"
+  else
+    Git_User="usmannasir"
+  fi
   Git_Content_URL="https://raw.githubusercontent.com/${Git_User}/cyberpanel"
   Git_Clone_URL="https://github.com/${Git_User}/cyberpanel.git"
 else
-  Git_User="qtwrk"
+  if [[ -n "$Git_User_Override" ]]; then
+    Git_User="$Git_User_Override"
+  else
+    Git_User="qtwrk"
+  fi
   Git_Content_URL="https://gitee.com/${Git_User}/cyberpanel/raw"
   Git_Clone_URL="https://gitee.com/${Git_User}/cyberpanel.git"
 fi
@@ -2567,9 +2688,11 @@ fi
 rm -rf /etc/profile.d/cyberpanel*
 curl --silent -o /etc/profile.d/cyberpanel.sh https://cyberpanel.sh/?banner 2>/dev/null
 chmod 700 /etc/profile.d/cyberpanel.sh
+echo "$Admin_User" > /etc/cyberpanel/adminUser
+chmod 600 /etc/cyberpanel/adminUser
 echo "$Admin_Pass" > /etc/cyberpanel/adminPass
 chmod 600 /etc/cyberpanel/adminPass
-/usr/local/CyberPanel/bin/python /usr/local/CyberCP/plogical/adminPass.py --password "$Admin_Pass"
+/usr/local/CyberPanel/bin/python /usr/local/CyberCP/plogical/adminPass.py --username "$Admin_User" --password "$Admin_Pass"
 mkdir -p /etc/opendkim
 
 echo '/usr/local/CyberPanel/bin/python /usr/local/CyberCP/plogical/adminPass.py --password "$@"' > /usr/bin/adminPass
@@ -2708,6 +2831,8 @@ Check_Process
 Check_Provider
 
 Check_Argument "$@"
+
+Apply_Container_Env
 
 if [[ $Silent = "On" ]]; then
   Argument_Mode

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -79,6 +79,7 @@ Branch_Name="v${Panel_Version}.${Panel_Build}"
 Base_Number="1.9.3"
 
 Git_User=""
+Git_User_Override=""
 Git_Content_URL=""
 Git_Clone_URL=""
 
@@ -354,19 +355,46 @@ done
 }
 
 Check_Argument() {
-if [[ "$*" = *"--branch "* ]] || [[ "$*" = *"-b "* ]]; then
-  Branch_Name=$(echo "$*" | sed -e "s/--branch //" -e "s/--mirror//" -e "s/-b //")
-  Branch_Check "$Branch_Name"
+if [[ -n "${CYBERPANEL_GIT_USER:-}" ]]; then
+  Git_User_Override="${CYBERPANEL_GIT_USER}"
 fi
+if [[ -n "${CYBERPANEL_BRANCH:-}" ]]; then
+  Branch_Name="${CYBERPANEL_BRANCH}"
+fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -b|--branch)
+      shift
+      Branch_Check "${1:-}"
+      shift
+      ;;
+    -r|--repo)
+      shift
+      Git_User_Override="${1:-}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
 }
 
 Pre_Upgrade_Setup_Git_URL() {
   if [[ $Server_Country != "CN" ]] ; then
-    Git_User="usmannasir"
+    if [[ -n "$Git_User_Override" ]]; then
+      Git_User="$Git_User_Override"
+    else
+      Git_User="usmannasir"
+    fi
     Git_Content_URL="https://raw.githubusercontent.com/${Git_User}/cyberpanel"
     Git_Clone_URL="https://github.com/${Git_User}/cyberpanel.git"
   else
-    Git_User="qtwrk"
+    if [[ -n "$Git_User_Override" ]]; then
+      Git_User="$Git_User_Override"
+    else
+      Git_User="qtwrk"
+    fi
     Git_Content_URL="https://gitee.com/${Git_User}/cyberpanel/raw"
     Git_Clone_URL="https://gitee.com/${Git_User}/cyberpanel.git"
   fi
@@ -1667,6 +1695,8 @@ fi
 Pre_Upgrade_Setup_Repository
 
 Pre_Upgrade_Setup_Git_URL
+export CYBERPANEL_GIT_USER="${Git_User}"
+export CYBERPANEL_BRANCH="${Branch_Name}"
 
 Pre_Upgrade_Required_Components
 

--- a/install.sh
+++ b/install.sh
@@ -71,29 +71,47 @@ fi
 rm -f cyberpanel.sh
 rm -f install.tar.gz
 
-if echo "$OUTPUT" | grep -q "Ubuntu 26.04" ; then
-        INSTALL_BRANCH="stable"
-        EXPECT_BRANCH=0
-        for argument do
-                if [ "$EXPECT_BRANCH" -eq 1 ]; then
-                        INSTALL_BRANCH="$argument"
-                        EXPECT_BRANCH=0
-                elif [ "$argument" = "-b" ]; then
-                        EXPECT_BRANCH=1
-                fi
-        done
+CYBERPANEL_GIT_USER="${CYBERPANEL_GIT_USER:-usmannasir}"
+CYBERPANEL_BRANCH="${CYBERPANEL_BRANCH:-}"
+export CYBERPANEL_GIT_USER CYBERPANEL_BRANCH
 
-        case "$INSTALL_BRANCH" in
-                ""|*[!A-Za-z0-9._/-]*) INSTALL_BRANCH="stable" ;;
-                [0-9]*) INSTALL_BRANCH="v$INSTALL_BRANCH" ;;
-        esac
+INSTALL_BRANCH="$CYBERPANEL_BRANCH"
+EXPECT_BRANCH=0
+for argument do
+        if [ "$EXPECT_BRANCH" -eq 1 ]; then
+                INSTALL_BRANCH="$argument"
+                EXPECT_BRANCH=0
+        elif [ "$argument" = "-b" ] || [ "$argument" = "--branch" ]; then
+                EXPECT_BRANCH=1
+        elif [ "$argument" = "-r" ] || [ "$argument" = "--repo" ]; then
+                EXPECT_BRANCH=2
+        elif [ "$EXPECT_BRANCH" -eq 2 ]; then
+                CYBERPANEL_GIT_USER="$argument"
+                export CYBERPANEL_GIT_USER
+                EXPECT_BRANCH=0
+        fi
+done
 
-        INSTALLER_URL="https://raw.githubusercontent.com/usmannasir/cyberpanel/$INSTALL_BRANCH/cyberpanel.sh"
+case "$INSTALL_BRANCH" in
+        "") ;;
+        *[!A-Za-z0-9._/-]*) INSTALL_BRANCH="" ;;
+        [0-9]*) INSTALL_BRANCH="v$INSTALL_BRANCH" ;;
+        v*) ;;
+        *) INSTALL_BRANCH="v$INSTALL_BRANCH" ;;
+esac
+if [ -n "$INSTALL_BRANCH" ]; then
+        export CYBERPANEL_BRANCH="$INSTALL_BRANCH"
+fi
+
+if [ -n "$INSTALL_BRANCH" ]; then
+        INSTALLER_URL="https://raw.githubusercontent.com/${CYBERPANEL_GIT_USER}/cyberpanel/${INSTALL_BRANCH}/cyberpanel.sh"
         if ! curl --fail --location --silent --show-error -o cyberpanel.sh "$INSTALLER_URL" ; then
-                curl --fail --location --silent --show-error -o cyberpanel.sh "https://cyberpanel.sh/?dl&$SERVER_OS"
+                echo "Failed to download installer from ${INSTALLER_URL}" >&2
+                curl --silent -o cyberpanel.sh "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null || exit 1
         fi
 else
-        curl --silent -o cyberpanel.sh "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null
+        # No branch selected: historical CDN bootstrap
+        curl --silent -o cyberpanel.sh "https://cyberpanel.sh/?dl&$SERVER_OS" 2>/dev/null || exit 1
 fi
 chmod +x cyberpanel.sh
 ./cyberpanel.sh $@

--- a/install/install.py
+++ b/install/install.py
@@ -2917,6 +2917,7 @@ def main():
     parser.add_argument('--mysqluser', help='MySQL user if remote is chosen.')
     parser.add_argument('--mysqlpassword', help='MySQL password if remote is chosen.')
     parser.add_argument('--mysqlport', help='MySQL port if remote is chosen.')
+    parser.add_argument('--container', default='OFF', help='Container runtime install (ON/OFF).')
 
     args = parser.parse_args()
 

--- a/plogical/adminPass.py
+++ b/plogical/adminPass.py
@@ -1,5 +1,6 @@
 #!/usr/local/CyberCP/bin/python
 import os.path
+import re
 import sys
 import django
 sys.path.append('/usr/local/CyberCP')
@@ -20,19 +21,23 @@ if not os.geteuid() == 0:
 def main():
 
     parser = argparse.ArgumentParser(description='Reset admin user password!')
+    parser.add_argument('--username', help='Admin username (default: admin)', default='admin')
     parser.add_argument('--password', help='New Password')
     parser.add_argument('--api', help='Enable/Disable API')
     args = parser.parse_args()
+    adminUser = (args.username or 'admin').strip()
+    if not re.match(r'^[A-Za-z0-9_]{3,32}$', adminUser):
+        sys.exit("\nInvalid username. Use 3-32 characters: letters, numbers, underscore.\n")
 
     if args.api != None:
         if args.api == '1':
-            admin = Administrator.objects.get(userName="admin")
+            admin = Administrator.objects.get(userName=adminUser)
             ensure_api_token(admin)
             admin.api = 1
             admin.save()
             print("API Enabled.")
         else:
-            admin = Administrator.objects.get(userName="admin")
+            admin = Administrator.objects.get(userName=adminUser)
             admin.api = 0
             admin.save()
             print("API Disabled.")
@@ -45,10 +50,10 @@ def main():
 
             ACLManager.createDefaultACLs()
             acl = ACL.objects.get(name='admin')
-            token = hashPassword.generateToken('admin', adminPass)
+            token = hashPassword.generateToken(adminUser, adminPass)
 
-            email = 'admin@cyberpanel.net'
-            admin = Administrator(userName="admin", password=hashPassword.hash_password(adminPass), type=1, email=email,
+            email = f"{adminUser}@cyberpanel.net"
+            admin = Administrator(userName=adminUser, password=hashPassword.hash_password(adminPass), type=1, email=email,
                                   firstName="Cyber", lastName="Panel", acl=acl, token=token)
             admin.save()
 
@@ -64,8 +69,8 @@ def main():
             print("Admin password successfully changed!")
             return 1
 
-        token = hashPassword.generateToken('admin', adminPass)
-        admin = Administrator.objects.get(userName="admin")
+        token = hashPassword.generateToken(adminUser, adminPass)
+        admin = Administrator.objects.get(userName=adminUser)
         admin.password = hashPassword.hash_password(adminPass)
         admin.token = token
         admin.save()


### PR DESCRIPTION
## Summary

Installer/upgrade path improvements for AlmaLinux 10 and fork-friendly installs: selectable GitHub repo/branch, optional admin username, container install flag, and safer branch parsing (including `-dev` suffixes).

Replaces part of #1901 (installer/EL10 portion). Keep #1901 open as reference. Base: `usmannasir:v3.0.4-dev` (`24b648f2`).

## Changes

### Fixes / updates

- `install.sh`: `--repo` / `-r` and `--branch` / `-b` parsing; default GitHub user `usmannasir`; CDN bootstrap when no branch is set
- `cyberpanel.sh`: `--repo`, `--username`, `CYBERPANEL_*` env overrides, container silent mode (`Apply_Container_Env`), branch check accepts `3.0.4-dev` style names
- `cyberpanel_upgrade.sh`: `--repo` / `--branch` and `CYBERPANEL_GIT_USER` / `CYBERPANEL_BRANCH` export into upgrade clone path
- `plogical/adminPass.py`: `--username` (validated 3-32 `[A-Za-z0-9_]`) for create/reset/API toggle
- `install/install.py`: `--container ON|OFF` flag for container runtime installs

### Removals

- None (additive). Upstream-safe defaults (no fork `master3395` hardcode in this PR).

## Tests / smoke

| Check | Result |
|-------|--------|
| `py_compile` on `plogical/adminPass.py`, `install/install.py` | PASS |
| Live AlmaLinux 10 fresh install | NOT RUN |
| Live AlmaLinux 10 upgrade path | NOT RUN |
| Docker / Hyper-V smoke | SKIPPED (no Docker CLI) |

Environment: Windows Cursor Local, 27/08/2026.

## Fresh-install + upgrade evidence

Operators on AlmaLinux 10:

```bash
# Fresh (example)
export CYBERPANEL_BRANCH=v3.0.4-dev
bash install.sh -b v3.0.4-dev -r usmannasir

# Upgrade (example)
export CYBERPANEL_GIT_USER=usmannasir
bash cyberpanel_upgrade.sh --branch v3.0.4-dev --repo usmannasir
```

## Out of scope

- Docker panel images / `Test/docker` / Hyper-V harness (see #1912)
- Cloudflare token auth (next PR)
- fail2ban / autoBan plugins
- `plogical/upgrade.py` live-ops rewrites
- `to-do/` planning scratch, `.cursor/plans`, VirtualBox `.vagrant`
