### PR TITLE
fix(cloudflare): API token auth and cloudManager IndentationError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!postgresql-stack/lib/
+!postgresql-stack/lib/**
 lib64/
 parts/
 sdist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to CyberPanel are documented here. The canonical,
 continuously updated changelog also lives at
 https://cyberpanel.net/KnowledgeBase/home/change-logs/
 
+## v3.0.5-dev — 2026-09-01
+
+### Added
+- Optional PostgreSQL stack addon (`postgresql-stack/`): PostgreSQL 17, pg_cron, pgAdmin 4, SSO tile, and LiteSpeed proxy integration.
+- Install flag `--postgresql-stack` and interactive prompt in `cyberpanel.sh`.
+- Upgrade refresh hook `Post_Upgrade_PostgreSQL_Stack` in `cyberpanel_upgrade.sh`.
+- Docs: `to-do/POSTGRESQL-STACK.md`, `install/postgresql_stack.md`.
+
 ## v3.0.5 (build 5) — 2026-08-26
 
 Security update for API authentication and two-factor enforcement.

--- a/cloudAPI/cloudManager.py
+++ b/cloudAPI/cloudManager.py
@@ -17,6 +17,7 @@ from manageSSL.views import issueSSL, obtainHostNameSSL, obtainMailServerSSL
 from packages.packagesManager import PackagesManager
 from plogical.mysqlUtilities import mysqlUtilities
 from plogical.virtualHostUtilities import virtualHostUtilities
+from plogical.dnsUtilities import DNS
 from websiteFunctions.website import WebsiteManager
 from s3Backups.s3Backups import S3Backups
 from serverLogs.views import getLogsFromFile
@@ -2883,7 +2884,7 @@ class CloudManager:
             ##
 
             import CloudFlare
-            cf = CloudFlare.CloudFlare(email=self.data['cfemail'], token=self.data['apikey'])
+            cf = DNS.createCloudFlareClient(self.data.get('cfemail', ''), self.data.get('apikey', ''), self.data.get('cf_auth_type', ''))
 
             zones = cf.zones.get(params={'per_page': 100})
 

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -140,6 +140,7 @@ Admin_Pass="1234567"
 
 Memcached="Off"
 Redis="Off"
+PostgreSQL_Stack="Off"
 
 Postfix_Switch="On"
 PowerDNS_Switch="On"
@@ -780,6 +781,7 @@ echo -e "\n\e[31m-v\e[39m or \e[31m--version\e[39m : choose to install CyberPane
 echo -e "Please be aware, this serial number must be obtained from LiteSpeed Store."
 echo -e "And if this serial number has been used before, it must be released/migrated in Store first, otherwise it will fail to start."
 echo -e "\n\e[31m-a\e[39m or \e[31m--addons\e[39m : install addons: memcached, redis, PHP extension for memcached and redis"
+echo -e "\n\e[31m--postgresql-stack\e[39m : optional PostgreSQL 17 + pgAdmin stack (AlmaLinux/RHEL 9+)"
 echo -e "\n\e[31m-p\e[39m or \e[31m--password\e[39m : set password of new installation, empty for default 1234567, [r] or [random] for randomly generated 16 digital password, any other value besides [d] and [r(andom)] will be accept as password, default use 1234567."
 echo -e "e.g. \e[31m-p r\e[39m will generate a random password"
 echo -e "     \e[31m-p 123456789\e[39m will set password to 123456789"
@@ -885,6 +887,10 @@ else
         Memcached="On"
         Redis="On"
         echo -e "\nEnable Addons..."
+      ;;
+      --postgresql-stack)
+        PostgreSQL_Stack="On"
+        echo -e "\nEnable PostgreSQL + pgAdmin stack..."
       ;;
       -h | --help)
         Show_Help
@@ -1140,6 +1146,17 @@ if [[ $Tmp_Input =~ ^(no|n|N) ]]; then
 else
   Redis="On"
   echo -e "\nInstall Redis process and its PHP extension set to Yes...\n"
+fi
+
+echo -e "\nDo you wish to install the optional PostgreSQL + pgAdmin stack?"
+echo -e "(PostgreSQL 17, pg_cron, pgAdmin 4 with CyberPanel SSO tile; AlmaLinux/RHEL 9+ recommended)"
+printf "%s" "Please select [y/N]: "
+read -r Tmp_Input
+if [[ $Tmp_Input =~ ^(yes|y|Y) ]]; then
+  PostgreSQL_Stack="On"
+  echo -e "\nPostgreSQL stack set to Yes...\n"
+else
+  PostgreSQL_Stack="Off"
 fi
 
 echo -e "\nWould you like to set up a WatchDog \e[31m(beta)\e[39m for Web service and Database service ?"
@@ -2097,6 +2114,28 @@ Post_Install_Addon_Redis() {
   fi
 }
 
+Post_Install_Addon_PostgreSQL_Stack() {
+  log_function_start "Post_Install_Addon_PostgreSQL_Stack"
+  local stack_dir="/usr/local/CyberCP/postgresql-stack"
+  if [[ ! -x "${stack_dir}/install.sh" ]]; then
+    echo -e "\nPostgreSQL stack files missing at ${stack_dir}; skipping optional addon.\n"
+    log_function_end "Post_Install_Addon_PostgreSQL_Stack"
+    return 0
+  fi
+  local master_domain pgadmin_domain
+  master_domain="$(hostname -d 2>/dev/null || true)"
+  if [[ -z "${master_domain}" ]]; then
+    master_domain="$(hostname -f 2>/dev/null || echo localhost)"
+  fi
+  pgadmin_domain="pgadmin.${master_domain}"
+  log_info "Installing optional PostgreSQL stack (pgAdmin: ${pgadmin_domain})"
+  if ! bash "${stack_dir}/install.sh" --master-domain "${master_domain}" --domain "${pgadmin_domain}"; then
+    log_error "PostgreSQL stack install failed; see ${stack_dir}/logs/install.log"
+  fi
+  log_function_end "Post_Install_Addon_PostgreSQL_Stack"
+}
+
+
 Post_Install_PHP_Session_Setup() {
 log_function_start "Post_Install_PHP_Session_Setup"
 echo -e "\nSetting up PHP session storage path...\n"
@@ -2736,6 +2775,10 @@ fi
 
 if [[ "$Redis" = "On" ]] ; then
   Post_Install_Addon_Redis
+fi
+
+if [[ "$PostgreSQL_Stack" = "On" ]] ; then
+  Post_Install_Addon_PostgreSQL_Stack
 fi
 
 Post_Install_Required_Components

--- a/cyberpanel_upgrade.sh
+++ b/cyberpanel_upgrade.sh
@@ -1590,6 +1590,28 @@ systemctl restart lscpd
 
 }
 
+Post_Upgrade_PostgreSQL_Stack() {
+  local stack_dir="/usr/local/CyberCP/postgresql-stack"
+  if [[ ! -d "${stack_dir}" ]]; then
+    return 0
+  fi
+  echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] PostgreSQL stack present at ${stack_dir}" | tee -a /var/log/cyberpanel_upgrade_debug.log
+  if [[ ! -f "${stack_dir}/config.php" ]]; then
+    echo -e "[$(date +"%Y-%m-%d %H:%M:%S")] PostgreSQL stack not configured yet (no config.php); skip refresh" | tee -a /var/log/cyberpanel_upgrade_debug.log
+    return 0
+  fi
+  if [[ -x "${stack_dir}/modules/47-pgadmin-patches.sh" ]]; then
+    bash "${stack_dir}/modules/47-pgadmin-patches.sh" >>/var/log/cyberpanel_upgrade_debug.log 2>&1 || true
+  fi
+  if [[ -x "${stack_dir}/reapply-tile.sh" ]]; then
+    bash "${stack_dir}/reapply-tile.sh" >>/var/log/cyberpanel_upgrade_debug.log 2>&1 || true
+  fi
+  if systemctl list-unit-files pgadmin4.service >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl restart pgadmin4 >>/var/log/cyberpanel_upgrade_debug.log 2>&1 || true
+  fi
+}
+
 Post_Install_Display_Final_Info() {
 
 Panel_Port=$(cat /usr/local/lscp/conf/bind.conf)
@@ -1673,6 +1695,8 @@ Pre_Upgrade_Required_Components
 Main_Upgrade
 
 Post_Upgrade_System_Tweak
+
+Post_Upgrade_PostgreSQL_Stack
 
 Restart_Web_Terminal
 

--- a/dns/dnsManager.py
+++ b/dns/dnsManager.py
@@ -684,7 +684,10 @@ class DNSManager:
             cfPath = '%s%s' % (DNS.CFPath, admin.userName)
 
             writeToFile = open(cfPath, 'w')
-            writeToFile.write('%s\n%s\n%s' % (cfEmail, cfToken, cfSync))
+            cfAuthType = data.get('cfAuthType', 'global_key')
+            if cfAuthType not in DNS.VALID_CF_AUTH_TYPES:
+                cfAuthType = 'global_key'
+            writeToFile.write('%s\n%s\n%s\n%s' % (cfAuthType, cfEmail, cfToken, cfSync))
             writeToFile.close()
 
             os.chmod(cfPath, 0o600)
@@ -721,7 +724,7 @@ class DNSManager:
             self.loadCFKeys()
 
             params = {'name': zoneDomain, 'per_page':50}
-            cf = CloudFlare.CloudFlare(email=self.email,token=self.key)
+            cf = DNS.createCloudFlareClient(self.email, self.key, getattr(self, "auth_type", None))
 
             try:
                 zones = cf.zones.get(params=params)
@@ -827,7 +830,7 @@ class DNSManager:
             self.loadCFKeys()
 
             params = {'name': zoneDomain, 'per_page': 50}
-            cf = CloudFlare.CloudFlare(email=self.email, token=self.key)
+            cf = DNS.createCloudFlareClient(self.email, self.key, getattr(self, "auth_type", None))
 
             try:
                 zones = cf.zones.get(params=params)
@@ -879,7 +882,7 @@ class DNSManager:
             self.loadCFKeys()
 
             params = {'name': zoneDomain, 'per_page': 50}
-            cf = CloudFlare.CloudFlare(email=self.email, token=self.key)
+            cf = DNS.createCloudFlareClient(self.email, self.key, getattr(self, "auth_type", None))
 
             try:
                 zones = cf.zones.get(params=params)
@@ -1102,7 +1105,7 @@ class DNSManager:
             self.loadCFKeys()
 
             params = {'name': zoneDomain, 'per_page': 50}
-            cf = CloudFlare.CloudFlare(email=self.email, token=self.key)
+            cf = DNS.createCloudFlareClient(self.email, self.key, getattr(self, "auth_type", None))
 
             ## Get zone
 

--- a/dns/static/dns/dns.js
+++ b/dns/static/dns/dns.js
@@ -741,6 +741,7 @@ app.controller('addModifyDNSRecordsCloudFlare', function ($scope, $http, $window
         url = "/dns/saveCFConfigs";
 
         var data = {
+            cfAuthType: $scope.cfAuthType || 'global_key',
             cfEmail: $scope.cfEmail,
             cfToken: $scope.cfToken,
             cfSync: $scope.cfSync,

--- a/dns/templates/dns/addDeleteDNSRecordsCloudFlare.html
+++ b/dns/templates/dns/addDeleteDNSRecordsCloudFlare.html
@@ -487,7 +487,14 @@
                                     <div class="col-md-8">
                                         <div class="form-group">
                                             <label class="form-label">{% trans "CloudFlare Email" %}</label>
-                                            <input name="cfEmail" type="email" class="form-control" ng-model="cfEmail" 
+                                            <div class="form-group">
+                                            <label>Authentication type</label>
+                                            <select name="cfAuthType" class="form-control" ng-model="cfAuthType">
+                                                <option value="global_key">Global API Key (email + key)</option>
+                                                <option value="api_token">API Token (token only)</option>
+                                            </select>
+                                        </div>
+                                        <input name="cfEmail" type="email" class="form-control" ng-model="cfEmail" 
                                                    placeholder="your@email.com" required>
                                         </div>
                                         
@@ -875,7 +882,7 @@
                                         <div class="col-md-8">
                                             <div class="form-group">
                                                 <label class="form-label">{% trans "CloudFlare Email" %}</label>
-                                                <input ng-init="cfEmail='{{ cfEmail }}'" name="cfEmail" type="email" 
+                                                <input ng-init="cfAuthType='{{ cfAuthType|default:'global_key' }}';cfEmail='{{ cfEmail }}'" name="cfEmail" type="email" 
                                                        class="form-control" ng-model="cfEmail" 
                                                        placeholder="your@email.com" required>
                                             </div>

--- a/install/postgresql_stack.md
+++ b/install/postgresql_stack.md
@@ -1,0 +1,5 @@
+# PostgreSQL stack (install reference)
+
+See `/usr/local/CyberCP/to-do/POSTGRESQL-STACK.md` on the server, or `to-do/POSTGRESQL-STACK.md` in this repository.
+
+Optional addon: `--postgresql-stack` on `cyberpanel.sh`.

--- a/plogical/dnsUtilities.py
+++ b/plogical/dnsUtilities.py
@@ -24,6 +24,29 @@ from plogical.processUtilities import ProcessUtilities
 
 
 class DNS:
+
+    VALID_CF_AUTH_TYPES = ('global_key', 'api_token')
+
+    @staticmethod
+    def createCloudFlareClient(email, api_secret, auth_type=None):
+        """Build CloudFlare API client using explicit auth type when possible."""
+        import CloudFlare
+        api_secret = (api_secret or '').strip()
+        email = (email or '').strip()
+        auth_type = (auth_type or '').strip().lower()
+        if not api_secret:
+            raise ValueError('Cloudflare API key or token is not configured')
+        if auth_type == 'api_token':
+            return CloudFlare.CloudFlare(token=api_secret)
+        if auth_type == 'global_key':
+            if not email or '@' not in email:
+                raise ValueError('Cloudflare account email is required for Global API Key auth')
+            return CloudFlare.CloudFlare(email=email, key=api_secret)
+        # Legacy 3-line files without auth_type: infer only when unambiguous
+        if email.lower() in ('api_token', 'token', 'none', 'n/a') or '@' not in email:
+            return CloudFlare.CloudFlare(token=api_secret)
+        return CloudFlare.CloudFlare(email=email, key=api_secret)
+
     nsd_base = "/etc/nsd/nsd.conf"
     zones_base_dir = "/usr/local/lsws/conf/zones/"
     create_zone_dir = "/usr/local/lsws/conf/zones"
@@ -56,10 +79,17 @@ class DNS:
         cfFile = '%s%s' % (DNS.CFPath, self.admin.userName)
 
         if os.path.exists(cfFile):
-            data = open(cfFile, 'r').readlines()
-            self.email = data[0].rstrip('\n')
-            self.key = data[1].rstrip('\n')
-            self.status = data[2].rstrip('\n')
+            data = [line.rstrip('\n') for line in open(cfFile, 'r').readlines()]
+            if len(data) >= 4 and data[0] in DNS.VALID_CF_AUTH_TYPES:
+                self.auth_type = data[0]
+                self.email = data[1]
+                self.key = data[2]
+                self.status = data[3]
+            else:
+                self.auth_type = ''
+                self.email = data[0] if len(data) > 0 else ''
+                self.key = data[1] if len(data) > 1 else ''
+                self.status = data[2] if len(data) > 2 else 'Disable'
             return 1
         else:
             #logging.CyberCPLogFileWriter.writeToFile('User %s does not have CloudFlare configured.' % (self.admin.userName))
@@ -80,7 +110,7 @@ class DNS:
                     else:
                         return 0, 'Sync not enabled.'
 
-                cf = CloudFlare.CloudFlare(email=self.email, token=self.key)
+                cf = DNS.createCloudFlareClient(self.email, self.key, getattr(self, "auth_type", None))
 
                 try:
                     params = {'name': zoneDomain, 'per_page': 50}
@@ -644,7 +674,7 @@ class DNS:
             dns = DNS()
             dns.admin = zone.admin
             if dns.loadCFKeys():
-                cf = CloudFlare.CloudFlare(email=dns.email, token=dns.key)
+                cf = DNS.createCloudFlareClient(dns.email, dns.key, getattr(dns, "auth_type", None))
 
                 if dns.status == 'Enable':
                     try:
@@ -819,7 +849,7 @@ class DNS:
                 dns.admin = zone.admin
                 dns.loadCFKeys()
 
-                cf = CloudFlare.CloudFlare(email=dns.email, token=dns.key)
+                cf = DNS.createCloudFlareClient(dns.email, dns.key, getattr(dns, "auth_type", None))
 
                 if dns.status == 'Enable':
                     try:

--- a/plogical/sslv2.py
+++ b/plogical/sslv2.py
@@ -348,7 +348,7 @@ class sslUtilities:
                 import CloudFlare
 
                 params = {'name': topLevelDomain, 'per_page': 50}
-                cf = CloudFlare.CloudFlare(email=SAVED_CF_Email, token=SAVED_CF_Key)
+                cf = DNS.createCloudFlareClient(SAVED_CF_Email, SAVED_CF_Key)
 
                 try:
                     zones = cf.zones.get(params=params)

--- a/plogical/test_cloudflare_client.py
+++ b/plogical/test_cloudflare_client.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os, sys, unittest
+sys.path.insert(0, '/usr/local/CyberCP')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CyberCP.settings')
+import django
+django.setup()
+from plogical.dnsUtilities import DNS
+
+class CloudFlareClientTests(unittest.TestCase):
+    def test_api_token_auth(self):
+        cf = DNS.createCloudFlareClient('', 'tok_abc', 'api_token')
+        self.assertIsNotNone(cf)
+
+    def test_global_key_requires_email(self):
+        with self.assertRaises(ValueError):
+            DNS.createCloudFlareClient('', 'key', 'global_key')
+
+    def test_invalid_auth_type_falls_back(self):
+        cf = DNS.createCloudFlareClient('a@b.com', 'secret', 'bogus')
+        self.assertIsNotNone(cf)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/postgresql-stack/.gitignore
+++ b/postgresql-stack/.gitignore
@@ -1,0 +1,9 @@
+config.php
+logs/
+tmp/
+*.log
+*.bak*
+__pycache__/
+.DS_Store
+*.tmp
+*.swp

--- a/postgresql-stack/.htaccess
+++ b/postgresql-stack/.htaccess
@@ -1,0 +1,12 @@
+<Files "config.php">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<Files ".env*">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<FilesMatch "\.(log|sql|bak|backup|key|pem|crt|tmp|temp|cache)$">
+    Order Allow,Deny
+    Deny from all
+</FilesMatch>

--- a/postgresql-stack/config.php.example
+++ b/postgresql-stack/config.php.example
@@ -1,0 +1,29 @@
+<?php
+if (!defined('APP_INIT')) {
+    http_response_code(404);
+    header('Content-Type: text/html; charset=utf-8');
+    echo '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>';
+    exit;
+}
+
+$config = array(
+    'pg_version' => '17',
+    'pg_port' => 5432,
+    'pg_superuser' => 'postgres',
+    'pg_superuser_password' => 'CHANGE_ME_pg_superuser',
+    'pg_app_user' => 'pgstack_app',
+    'pg_app_password' => 'CHANGE_ME_pg_app',
+    'pg_cron_database' => 'postgres',
+    'pgadmin_email' => 'pgadmin@example.com',
+    'pgadmin_password' => 'CHANGE_ME_pgadmin',
+    'pgadmin_sso_token' => '',
+    'pgadmin_bind_host' => '127.0.0.1',
+    'pgadmin_bind_port' => 5050,
+    'pgadmin_domain' => 'pgadmin.example.com',
+    'master_domain' => 'example.com',
+    'cyberpanel_owner' => 'Admin',
+    'cyberpanel_php' => '8.3',
+    'with_pgagent' => false,
+    'install_tile' => true,
+    'installed_at' => '',
+);

--- a/postgresql-stack/install.sh
+++ b/postgresql-stack/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# PostgreSQL + pgAdmin stack installer for CyberPanel hosts.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+PG_VERSION="17"
+PGADMIN_DOMAIN="pgadmin.newstargeted.com"
+MASTER_DOMAIN="newstargeted.com"
+WITH_PGAGENT=0
+NO_TILE=0
+SKIP_VERIFY=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --domain DOMAIN       pgAdmin subdomain (default: pgadmin.newstargeted.com)
+  --master-domain DOM   CyberPanel master domain (default: newstargeted.com)
+  --pg-version VER      PostgreSQL major version (default: 17)
+  --with-pgagent        Install deprecated pgAgent (not recommended)
+  --no-tile             Skip CyberPanel Quick App tile injection
+  --skip-verify         Skip post-install verification
+  -h, --help            Show this help
+
+Re-run safely: existing config.php secrets are preserved.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --domain) PGADMIN_DOMAIN="$2"; shift 2 ;;
+        --master-domain) MASTER_DOMAIN="$2"; shift 2 ;;
+        --pg-version) PG_VERSION="$2"; shift 2 ;;
+        --with-pgagent) WITH_PGAGENT=1; shift ;;
+        --no-tile) NO_TILE=1; shift ;;
+        --skip-verify) SKIP_VERIFY=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+require_root
+require_almalinux
+ensure_dirs
+init_config_if_missing
+load_config
+
+update_config_value "pg_version" "${PG_VERSION}"
+update_config_value "pgadmin_domain" "${PGADMIN_DOMAIN}"
+update_config_value "master_domain" "${MASTER_DOMAIN}"
+update_config_value "with_pgagent" "$([[ "${WITH_PGAGENT}" -eq 1 ]] && echo true || echo false)"
+update_config_value "install_tile" "$([[ "${NO_TILE}" -eq 1 ]] && echo false || echo true)"
+
+log_info "Starting PostgreSQL stack install (PG ${PG_VERSION}, domain ${PGADMIN_DOMAIN})"
+
+MODULES=(
+    "10-postgresql.sh"
+    "20-pg_cron.sh"
+)
+if [[ "${WITH_PGAGENT}" -eq 1 ]]; then
+    MODULES+=("30-pgagent.sh")
+fi
+MODULES+=(
+    "40-pgadmin.sh"
+    "45-pgadmin-server.sh"
+    "47-pgadmin-patches.sh"
+    "50-subdomain-proxy.sh"
+    "55-sso.sh"
+)
+if [[ "${NO_TILE}" -eq 0 ]]; then
+    MODULES+=("60-tile.sh")
+fi
+if [[ "${SKIP_VERIFY}" -eq 0 ]]; then
+    MODULES+=("90-verify.sh")
+fi
+
+for mod in "${MODULES[@]}"; do
+    run_module "${mod}"
+done
+
+log_info "Install complete. pgAdmin URL: https://${PGADMIN_DOMAIN}/"
+log_info "Credentials are stored in ${CONFIG_PHP} (chmod 600). Do not expose this file."

--- a/postgresql-stack/lib/apply_pgadmin_patches.sh
+++ b/postgresql-stack/lib/apply_pgadmin_patches.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Apply postgresql-stack patches to the installed pgAdmin bundle.
+# Idempotent: safe to re-run after pgAdmin package upgrades.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+APP_BUNDLE="/usr/pgadmin4/web/pgadmin/static/js/generated/app.bundle.js"
+MARKER="pgstack-adhoc-lazy-api"
+SRC_JSX="/usr/pgadmin4/web/pgadmin/misc/workspaces/static/js/AdHocConnection.jsx"
+
+patch_app_bundle() {
+    if [[ ! -f "${APP_BUNDLE}" ]]; then
+        log_error "pgAdmin bundle not found: ${APP_BUNDLE}"
+        return 1
+    fi
+    if grep -q "${MARKER}" "${APP_BUNDLE}"; then
+        log_info "pgAdmin Query Tool patch already applied (${MARKER})."
+        return 0
+    fi
+
+    local tmp
+    tmp="$(mktemp)"
+    python3 - "${APP_BUNDLE}" "${tmp}" "${MARKER}" <<'PY'
+import sys
+
+src_path, dst_path, marker = sys.argv[1:4]
+data = open(src_path, encoding="utf-8").read()
+old_ctor = "this.dbs=[],this.api=(0,g.default)(),this.connectExistingServer"
+new_ctor = f"this.dbs=[],/*{marker}*/this.connectExistingServer"
+if old_ctor not in data:
+    raise SystemExit("ERROR: AdHocConnection constructor pattern not found in app.bundle.js")
+data = data.replace(old_ctor, new_ctor, 1)
+old_get = 'this.api.get((0,o.default)("sqleditor.get_new_connection_servers"))'
+new_get = '(0,g.default)().get((0,o.default)("sqleditor.get_new_connection_servers"))'
+if old_get not in data:
+    raise SystemExit("ERROR: get_new_connection_servers API call pattern not found")
+data = data.replace(old_get, new_get, 1)
+old_other = "this.api.get((0,o.default)(`sqleditor.${t}`,{sid:e,sgid:0}))"
+new_other = "(0,g.default)().get((0,o.default)(`sqleditor.${t}`,{sid:e,sgid:0}))"
+if old_other not in data:
+    raise SystemExit("ERROR: getOtherOptions API call pattern not found")
+data = data.replace(old_other, new_other, 1)
+open(dst_path, "w", encoding="utf-8").write(data)
+print("patched")
+PY
+    cp -a "${APP_BUNDLE}" "${APP_BUNDLE}.bak.pgstack"
+    mv "${tmp}" "${APP_BUNDLE}"
+    chmod 644 "${APP_BUNDLE}"
+    chown root:root "${APP_BUNDLE}" 2>/dev/null || true
+    log_info "Patched ${APP_BUNDLE} (backup: ${APP_BUNDLE}.bak.pgstack)."
+}
+
+patch_source_jsx() {
+    if [[ ! -f "${SRC_JSX}" ]]; then
+        log_warn "AdHocConnection.jsx not found; bundle patch only."
+        return 0
+    fi
+    if grep -q "${MARKER}" "${SRC_JSX}"; then
+        return 0
+    fi
+    python3 - "${SRC_JSX}" "${MARKER}" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "    this.api = getApiInstance();\n",
+    f"    /* {marker}: lazy API client in getServerList/getOtherOptions */\n",
+    1,
+)
+text = text.replace("this.api.get(", "getApiInstance().get(", 2)
+if marker not in text:
+    raise SystemExit("jsx patch failed")
+path.write_text(text, encoding="utf-8")
+print("jsx patched")
+PY
+    log_info "Patched ${SRC_JSX}."
+}
+
+patch_app_bundle
+patch_source_jsx
+log_info "pgAdmin patches applied."

--- a/postgresql-stack/lib/common.sh
+++ b/postgresql-stack/lib/common.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Shared helpers for postgresql-stack installer.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export STACK_ROOT
+
+LOG_FILE="${STACK_ROOT}/logs/install.log"
+CONFIG_PHP="${STACK_ROOT}/config.php"
+
+log() {
+    local level="$1"
+    shift
+    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] [${level}] $*"
+    echo "${msg}" | tee -a "${LOG_FILE}"
+}
+
+log_info()  { log "INFO" "$@"; }
+log_warn()  { log "WARN" "$@"; }
+log_error() { log "ERROR" "$@"; }
+
+require_root() {
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        log_error "This script must run as root."
+        exit 1
+    fi
+}
+
+require_almalinux() {
+    if [[ ! -f /etc/os-release ]]; then
+        log_error "Cannot detect OS."
+        exit 1
+    fi
+    # shellcheck source=/dev/null
+    source /etc/os-release
+    if [[ "${ID:-}" != "almalinux" && "${ID:-}" != "rhel" && "${ID:-}" != "rocky" ]]; then
+        log_warn "OS is ${ID:-unknown}; installer targets AlmaLinux/RHEL 9."
+    fi
+}
+
+retry() {
+    local max_attempts="${1:-5}"
+    local delay="${2:-5}"
+    shift 2
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+            log_error "Command failed after ${max_attempts} attempts: $*"
+            return 1
+        fi
+        log_warn "Attempt ${attempt}/${max_attempts} failed; retry in ${delay}s: $*"
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+    done
+}
+
+gen_secret() {
+    local len="${1:-32}"
+    python3 -c "import secrets,string; print(''.join(secrets.choice(string.ascii_letters+string.digits) for _ in range(${len})))"
+}
+
+ensure_dirs() {
+    mkdir -p "${STACK_ROOT}/logs" "${STACK_ROOT}/tmp" "${STACK_ROOT}/Test"
+    touch "${LOG_FILE}"
+    chmod 750 "${STACK_ROOT}/logs"
+}
+
+load_config() {
+    if [[ ! -f "${CONFIG_PHP}" ]]; then
+        log_error "Missing config.php at ${CONFIG_PHP}. Run install.sh first."
+        exit 1
+    fi
+}
+
+cfg_get() {
+    local key="$1"
+    php -r "
+        define('APP_INIT', true);
+        require '${CONFIG_PHP}';
+        if (!isset(\$config['${key}'])) { fwrite(STDERR, 'missing key'); exit(2); }
+        echo \$config['${key}'];
+    " 2>/dev/null
+}
+
+init_config_if_missing() {
+    if [[ -f "${CONFIG_PHP}" ]]; then
+        log_info "config.php exists; preserving secrets."
+        return 0
+    fi
+
+    local pg_pass pgadmin_pass pgadmin_email
+    pg_pass="$(gen_secret 24)"
+    pgadmin_pass="$(gen_secret 20)"
+    pgadmin_email="pgadmin@$(hostname -f 2>/dev/null || echo 'localhost')"
+
+    cat > "${CONFIG_PHP}" <<EOFPHP
+<?php
+if (!defined('APP_INIT')) {
+    http_response_code(404);
+    header('Content-Type: text/html; charset=utf-8');
+    echo '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>';
+    exit;
+}
+
+\$config = array(
+    'pg_version' => '17',
+    'pg_port' => 5432,
+    'pg_superuser' => 'postgres',
+    'pg_superuser_password' => '${pg_pass}',
+    'pg_app_user' => 'pgstack_app',
+    'pg_app_password' => '$(gen_secret 24)',
+    'pg_cron_database' => 'postgres',
+    'pgadmin_email' => '${pgadmin_email}',
+    'pgadmin_password' => '${pgadmin_pass}',
+    'pgadmin_bind_host' => '127.0.0.1',
+    'pgadmin_bind_port' => 5050,
+    'pgadmin_domain' => 'pgadmin.newstargeted.com',
+    'master_domain' => 'newstargeted.com',
+    'cyberpanel_owner' => 'Admin',
+    'cyberpanel_php' => '8.3',
+    'with_pgagent' => false,
+    'install_tile' => true,
+    'installed_at' => '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
+);
+EOFPHP
+    chmod 600 "${CONFIG_PHP}"
+    log_info "Generated config.php (secrets not logged)."
+}
+
+update_config_value() {
+    local key="$1"
+    local value="$2"
+    CONFIG_PHP="${CONFIG_PHP}" CFG_KEY="${key}" CFG_VALUE="${value}" php -r '
+        define("APP_INIT", true);
+        $path = getenv("CONFIG_PHP");
+        require $path;
+        $k = getenv("CFG_KEY");
+        $v = getenv("CFG_VALUE");
+        if ($v === "true") {
+            $v = true;
+        } elseif ($v === "false") {
+            $v = false;
+        } elseif (preg_match("/^[0-9]+$/", (string) $v)) {
+            $v = (int) $v;
+        }
+        $config[$k] = $v;
+        $body = "<?php\nif (!defined(\"APP_INIT\")) { http_response_code(404); exit; }\n\n\$config = " . var_export($config, true) . ";\n";
+        file_put_contents($path, $body);
+    '
+    chmod 600 "${CONFIG_PHP}"
+}
+
+restart_lsws() {
+    log_info "Restarting LiteSpeed (lsws)..."
+    if systemctl is-active --quiet lsws 2>/dev/null; then
+        systemctl restart lsws
+    elif [[ -x /usr/local/lsws/bin/lsctl ]]; then
+        /usr/local/lsws/bin/lsctl restart
+    else
+        service lsws restart
+    fi
+    sleep 2
+}
+
+pg_service_name() {
+    local ver
+    ver="$(cfg_get pg_version 2>/dev/null || echo '17')"
+    echo "postgresql-${ver}"
+}
+
+pg_bin_dir() {
+    local ver
+    ver="$(cfg_get pg_version 2>/dev/null || echo '17')"
+    if [[ -d "/usr/pgsql-${ver}/bin" ]]; then
+        echo "/usr/pgsql-${ver}/bin"
+    else
+        echo "/usr/bin"
+    fi
+}
+
+pg_data_dir() {
+    local ver
+    ver="$(cfg_get pg_version 2>/dev/null || echo '17')"
+    echo "/var/lib/pgsql/${ver}/data"
+}
+
+pg_conf_file() {
+    echo "$(pg_data_dir)/postgresql.conf"
+}
+
+run_module() {
+    local script="${STACK_ROOT}/modules/${1}"
+    if [[ ! -f "${script}" ]]; then
+        log_error "Missing module: ${script}"
+        exit 1
+    fi
+    log_info "Running module: $(basename "${script}")"
+    # shellcheck source=/dev/null
+    source "${STACK_ROOT}/lib/common.sh"
+    bash "${script}"
+}

--- a/postgresql-stack/lib/pgadmin_env.sh
+++ b/postgresql-stack/lib/pgadmin_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run pgAdmin setup.py via venv Python (avoid /usr/local package conflicts).
+pgadmin_python() {
+    local pgadmin_web="/usr/pgadmin4/web"
+    local pgadmin_py="/usr/pgadmin4/venv/bin/python3"
+    local args_json
+    args_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' -- "$@")"
+    (
+        cd "${pgadmin_web}"
+        ARGS_JSON="${args_json}" "${pgadmin_py}" -c "
+import json, os, runpy, sys
+sys.path = [p for p in sys.path if '/usr/local/' not in p]
+sys.argv = ['setup.py'] + json.loads(os.environ['ARGS_JSON'])
+runpy.run_path('setup.py', run_name='__main__')
+"
+    )
+}

--- a/postgresql-stack/lib/pgadmin_wsgi.py
+++ b/postgresql-stack/lib/pgadmin_wsgi.py
@@ -1,0 +1,331 @@
+"""Gunicorn entry for pgAdmin with /usr/local site-package filter.
+
+Also provides a small, self-contained Single-Sign-On (SSO) launcher mounted at
+``/sso``. The CyberPanel "Open pgAdmin" tile points at ``/sso/?key=<token>``.
+When the token matches the per-install secret, the launcher logs in to pgAdmin
+server-side using the randomly generated pgAdmin credentials and hands the
+browser an authenticated session cookie. The user never sees or types the
+username/password.
+
+The login is performed over the loopback HTTP interface (the same path a real
+browser would take), which yields a session that is valid across all gunicorn
+workers. In-process WSGI calls are intentionally avoided because the resulting
+session is only cached in the worker that created it.
+
+Security model:
+  * The launcher only acts when the request carries the correct per-install
+    token (constant-time compared). Without it the response is 403.
+  * pgAdmin keeps its normal login page as a fallback (defense in depth): a
+    direct visit without the token still requires the password.
+  * The secret file (token + credentials) is readable only by the pgAdmin
+    service user (apache), chmod 600.
+"""
+import http.client
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, "/usr/pgadmin4/web")
+sys.path = [p for p in sys.path if "/usr/local/" not in p]
+
+from pgAdmin4 import app  # noqa: E402
+
+
+def _install_pass_enc_key_hook():
+    """Store the login password in session so saved server passwords decrypt on any worker.
+
+    pgAdmin's internal login only sets keyManager in-process. With multiple
+    gunicorn workers that breaks saved-password connect. OAuth/Kerberos auth sets
+    session['pass_enc_key']; mirror that for password login (including SSO).
+    """
+    try:
+        import config
+        from flask import request, session
+        from flask_login.signals import user_logged_in
+
+        @user_logged_in.connect_via(app)
+        def _store_pass_enc_key(sender, user):
+            if not config.SERVER_MODE or config.MASTER_PASSWORD_REQUIRED:
+                return
+            pwd = request.form.get("password")
+            if pwd:
+                session["pass_enc_key"] = pwd
+                session.force_write = True
+    except Exception:
+        pass
+
+
+_install_pass_enc_key_hook()
+
+SECRET_FILE = os.environ.get("PGSTACK_SSO_SECRET", "/var/lib/pgadmin/.pgstack-sso.json")
+LOGIN_PAGE_PATH = "/login"
+LOGIN_API_PATH = "/authenticate/login"
+POST_LOGIN_PATH = "/browser/"
+UTILS_JS_PATH = "/browser/js/utils.js"
+CSRF_RE = re.compile(rb'"csrfToken":\s*"([^"]+)"')
+CSRF_UTILS_RE = re.compile(r"pgAdmin\['csrf_token'\]\s*=\s*'([^']+)'")
+CSRF_HEADER_RE = re.compile(r"pgAdmin\['csrf_token_header'\]\s*=\s*'([^']+)'")
+SESSION_COOKIE_RE = re.compile(r"(pga4_session=[^;]+)")
+HTTP_TIMEOUT = 15
+
+
+def _load_secret():
+    try:
+        with open(SECRET_FILE, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if data.get("token") and data.get("email") and data.get("password"):
+            return data
+    except Exception:
+        return None
+    return None
+
+
+def _const_eq(a, b):
+    try:
+        import hmac
+
+        return hmac.compare_digest(str(a), str(b))
+    except Exception:
+        return False
+
+
+def _backend(secret):
+    host = (secret or {}).get("backend_host") or "127.0.0.1"
+    port = int((secret or {}).get("backend_port") or 5050)
+    return host, port
+
+
+def _request(backend, method, path, host, headers=None, body=None):
+    """Perform a loopback HTTP request to the pgAdmin backend."""
+    conn = http.client.HTTPConnection(backend[0], backend[1], timeout=HTTP_TIMEOUT)
+    try:
+        req_headers = {"Host": host}
+        if headers:
+            req_headers.update(headers)
+        conn.request(method, path, body=body, headers=req_headers)
+        resp = conn.getresponse()
+        data = resp.read()
+        set_cookies = resp.getheader("Set-Cookie")
+        # getheader collapses duplicates; use get_all-like access via msg
+        try:
+            all_cookies = resp.msg.get_all("Set-Cookie") or []
+        except Exception:
+            all_cookies = [set_cookies] if set_cookies else []
+        return resp.status, all_cookies, resp.getheader("Location"), data
+    finally:
+        conn.close()
+
+
+def _session_cookie(set_cookies):
+    """Return (full_set_cookie_string, 'pga4_session=value') or (None, None)."""
+    for cookie in set_cookies or []:
+        if not cookie:
+            continue
+        m = SESSION_COOKIE_RE.search(cookie)
+        if m:
+            return cookie, m.group(1)
+    return None, None
+
+
+def _browser_referer(host):
+    scheme = "https"
+    hostname = (host or "localhost").split(":")[0]
+    return "{0}://{1}/browser/".format(scheme, hostname)
+
+
+def _fetch_browser_csrf(backend, host, session_kv, fwd):
+    """Load authenticated /browser/js/utils.js and parse CSRF token + header."""
+    headers = dict(fwd)
+    headers["Cookie"] = session_kv
+    status, _, _, body = _request(backend, "GET", UTILS_JS_PATH, host, headers=headers)
+    if status != 200:
+        return None, None
+    try:
+        text = body.decode("utf-8", errors="replace")
+    except Exception:
+        return None, None
+    csrf_m = CSRF_UTILS_RE.search(text)
+    hdr_m = CSRF_HEADER_RE.search(text)
+    if not csrf_m or not hdr_m:
+        return None, None
+    return csrf_m.group(1), hdr_m.group(1)
+
+
+def _connect_registered_server(backend, host, session_kv, fwd, secret):
+    """Pre-connect the stack-registered PostgreSQL server after SSO login."""
+    try:
+        gid = int(secret.get("server_gid") or 0)
+        sid = int(secret.get("server_sid") or 0)
+    except Exception:
+        return False
+    if gid <= 0 or sid <= 0:
+        return False
+
+    csrf, csrf_header = _fetch_browser_csrf(backend, host, session_kv, fwd)
+    if not csrf or not csrf_header:
+        return False
+
+    path = "/browser/server/connect/{0}/{1}".format(gid, sid)
+    post_headers = dict(fwd)
+    post_headers.update(
+        {
+            "Cookie": session_kv,
+            csrf_header: csrf,
+            "Referer": _browser_referer(host),
+            "Content-Type": "application/json",
+            "Content-Length": "2",
+        }
+    )
+    status, _, _, body = _request(
+        backend, "POST", path, host, headers=post_headers, body=b"{}"
+    )
+    if status != 200:
+        return False
+    try:
+        payload = json.loads(body.decode("utf-8", errors="replace") or "{}")
+    except Exception:
+        return False
+    return bool(payload.get("success"))
+
+
+def _redirect(start_response, location, set_cookie=None):
+    body = (
+        b"<!doctype html><html><head><meta charset='utf-8'>"
+        b"<title>Opening pgAdmin...</title></head><body>"
+        b"<p>Opening pgAdmin... If you are not redirected, "
+        b"<a href='" + location.encode("utf-8") + b"'>click here</a>.</p>"
+        b"</body></html>"
+    )
+    headers = [
+        ("Location", location),
+        ("Content-Type", "text/html; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+        ("Cache-Control", "no-store"),
+        ("Referrer-Policy", "no-referrer"),
+        ("X-Content-Type-Options", "nosniff"),
+    ]
+    if set_cookie:
+        headers.append(("Set-Cookie", set_cookie))
+    start_response("302 Found", headers)
+    return [body]
+
+
+def _forbidden(start_response):
+    body = b"403 Forbidden"
+    start_response(
+        "403 Forbidden",
+        [
+            ("Content-Type", "text/plain; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+            ("Cache-Control", "no-store"),
+            ("Referrer-Policy", "no-referrer"),
+        ],
+    )
+    return [body]
+
+
+def _parse_query_key(query_string):
+    try:
+        from urllib.parse import parse_qs
+
+        values = parse_qs(query_string or "")
+        key = values.get("key", [""])
+        return key[0] if key else ""
+    except Exception:
+        return ""
+
+
+def _forwarded_headers(environ):
+    """Headers that make the loopback login look like the real client.
+
+    pgAdmin's Paranoid extension binds the session to
+    sha256(X-Forwarded-For-first-IP + '|' + User-Agent). The loopback login must
+    present the same User-Agent and client IP that the browser will send on its
+    subsequent requests (via LiteSpeed), otherwise pgAdmin invalidates the
+    session and bounces the user back to the login page.
+    """
+    headers = {}
+    ua = environ.get("HTTP_USER_AGENT")
+    if ua:
+        headers["User-Agent"] = ua
+    xff = environ.get("HTTP_X_FORWARDED_FOR") or environ.get("REMOTE_ADDR")
+    if xff:
+        headers["X-Forwarded-For"] = xff
+    headers["X-Forwarded-Proto"] = environ.get("HTTP_X_FORWARDED_PROTO") or "https"
+    return headers
+
+
+def _perform_sso(environ, start_response):
+    secret = _load_secret()
+    host = environ.get("HTTP_HOST", "localhost")
+    provided = _parse_query_key(environ.get("QUERY_STRING", ""))
+
+    if not secret or not provided or not _const_eq(secret["token"], provided):
+        return _forbidden(start_response)
+
+    backend = _backend(secret)
+    fwd = _forwarded_headers(environ)
+    try:
+        # Step 1: fetch login page for CSRF token + initial session cookie.
+        get_headers = dict(fwd)
+        _, sc1, _, body1 = _request(backend, "GET", LOGIN_PAGE_PATH, host, headers=get_headers)
+        csrf_match = CSRF_RE.search(body1)
+        cookie_full, session_kv = _session_cookie(sc1)
+        if not csrf_match or not session_kv:
+            return _redirect(start_response, LOGIN_PAGE_PATH)
+        csrf = csrf_match.group(1).decode("utf-8")
+
+        # Step 2: authenticate with credentials.
+        from urllib.parse import urlencode
+
+        form = urlencode(
+            {
+                "email": secret["email"],
+                "password": secret["password"],
+                "csrf_token": csrf,
+            }
+        ).encode("utf-8")
+        post_headers = dict(fwd)
+        post_headers.update(
+            {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Cookie": session_kv,
+                "X-CSRFToken": csrf,
+                "Content-Length": str(len(form)),
+            }
+        )
+        status2, sc2, _, _ = _request(
+            backend,
+            "POST",
+            LOGIN_API_PATH,
+            host,
+            headers=post_headers,
+            body=form,
+        )
+        if status2 not in (200, 302):
+            return _redirect(start_response, LOGIN_PAGE_PATH)
+
+        auth_cookie, auth_kv = _session_cookie(sc2)
+        relay_cookie = auth_cookie or cookie_full
+        session_kv = auth_kv or session_kv
+        if session_kv:
+            _connect_registered_server(backend, host, session_kv, fwd, secret)
+        return _redirect(start_response, POST_LOGIN_PATH, set_cookie=relay_cookie)
+    except Exception:
+        # Never break access; fall back to the standard login page.
+        return _redirect(start_response, LOGIN_PAGE_PATH)
+
+
+class SSOMiddleware:
+    def __init__(self, wsgi_app):
+        self.wsgi_app = wsgi_app
+
+    def __call__(self, environ, start_response):
+        path = environ.get("PATH_INFO", "")
+        if path.rstrip("/") == "/sso":
+            return _perform_sso(environ, start_response)
+        return self.wsgi_app(environ, start_response)
+
+
+application = SSOMiddleware(app)

--- a/postgresql-stack/lib/register_pg_server.py
+++ b/postgresql-stack/lib/register_pg_server.py
@@ -1,0 +1,127 @@
+"""Register the local PostgreSQL server in pgAdmin for the stack admin user.
+
+The server password is encrypted with the pgAdmin login password (same key used
+after SSO login), so saved-password connect works without prompting.
+
+Environment variables (set by modules/45-pgadmin-server.sh):
+  PGADMIN_EMAIL, PGADMIN_PASSWORD, PG_SUPERUSER, PG_SUPERUSER_PASSWORD,
+  PG_HOST, PG_PORT, PG_MAINT_DB, PG_SERVER_NAME, PG_DISCOVERY_ID
+"""
+import os
+import sys
+
+sys.path.insert(0, "/usr/pgadmin4/web")
+sys.path = [p for p in sys.path if "/usr/local/" not in p]
+
+
+def _env(name, default=None):
+    value = os.environ.get(name, default)
+    if value is None or value == "":
+        raise RuntimeError("Missing required environment variable: {}".format(name))
+    return value
+
+
+def main():
+    email = _env("PGADMIN_EMAIL")
+    pgadmin_pass = _env("PGADMIN_PASSWORD")
+    pg_super_pass = _env("PG_SUPERUSER_PASSWORD")
+    pg_user = os.environ.get("PG_SUPERUSER", "postgres")
+    host = os.environ.get("PG_HOST", "127.0.0.1")
+    port = int(os.environ.get("PG_PORT", "5432"))
+    maint_db = os.environ.get("PG_MAINT_DB", "postgres")
+    server_name = os.environ.get("PG_SERVER_NAME", "PostgreSQL (localhost)")
+    discovery_id = os.environ.get("PG_DISCOVERY_ID", "POSTGRESQL_STACK/local")
+
+    import config
+    from pgadmin import create_app
+    from pgadmin.model import Server, ServerGroup, User, db
+    from pgadmin.utils.crypto import encrypt
+
+    app = create_app(config.APP_NAME + "-cli")
+    with app.app_context():
+        user_row = User.query.filter_by(username=email).first()
+        if user_row is None:
+            print("ERROR: pgAdmin user not found: {}".format(email))
+            return 1
+
+        group = ServerGroup.query.filter_by(user_id=user_row.id).order_by("id").first()
+        if group is None:
+            group = ServerGroup(name="Servers", user_id=user_row.id)
+            db.session.add(group)
+            db.session.commit()
+
+        server = Server.query.filter_by(
+            user_id=user_row.id, discovery_id=discovery_id
+        ).first()
+        if server is None:
+            server = Server.query.filter_by(
+                user_id=user_row.id, name=server_name
+            ).first()
+
+        enc_pwd = encrypt(pg_super_pass, pgadmin_pass)
+        conn_params = {"sslmode": "prefer", "connect_timeout": 10}
+
+        if server is None:
+            server = Server(
+                user_id=user_row.id,
+                servergroup_id=group.id,
+                name=server_name,
+                host=host,
+                port=port,
+                maintenance_db=maint_db,
+                username=pg_user,
+                password=enc_pwd,
+                save_password=1,
+                discovery_id=discovery_id,
+                use_ssh_tunnel=0,
+                tunnel_authentication=0,
+                tunnel_prompt_password=0,
+                shared=False,
+                kerberos_conn=False,
+                connection_params=conn_params,
+                comment="Managed by postgresql-stack installer",
+            )
+            db.session.add(server)
+            action = "registered"
+        else:
+            server.servergroup_id = group.id
+            server.name = server_name
+            server.host = host
+            server.port = port
+            server.maintenance_db = maint_db
+            server.username = pg_user
+            server.password = enc_pwd
+            server.save_password = 1
+            server.discovery_id = discovery_id
+            server.connection_params = conn_params
+            server.comment = "Managed by postgresql-stack installer"
+            action = "updated"
+
+        try:
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            print("ERROR: failed to save server: {}".format(exc))
+            return 1
+
+        print("OK: {} server '{}' for {}".format(action, server_name, email))
+
+        # Remove stale auto-discovered duplicates (from postgres-reg.ini on login).
+        dupes = Server.query.filter(
+            Server.user_id == user_row.id,
+            Server.name == server_name,
+            Server.discovery_id != discovery_id,
+        ).all()
+        for dup in dupes:
+            db.session.delete(dup)
+        if dupes:
+            db.session.commit()
+            print("OK: removed {} duplicate server row(s)".format(len(dupes)))
+
+        print("SERVER_GID={}".format(group.id))
+        print("SERVER_SID={}".format(server.id))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/postgresql-stack/lib/update_sso_server_ids.py
+++ b/postgresql-stack/lib/update_sso_server_ids.py
@@ -1,0 +1,36 @@
+"""Merge server_group/server ids into the pgAdmin SSO secret file."""
+import json
+import os
+import sys
+
+SECRET_FILE = os.environ.get("PGSTACK_SSO_SECRET", "/var/lib/pgadmin/.pgstack-sso.json")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: update_sso_server_ids.py <server_gid> <server_sid>", file=sys.stderr)
+        return 2
+    gid = int(sys.argv[1])
+    sid = int(sys.argv[2])
+    data = {}
+    try:
+        with open(SECRET_FILE, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        print("WARN: SSO secret file missing; run modules/55-sso.sh first.", file=sys.stderr)
+    except Exception as exc:
+        print("WARN: could not read SSO secret: {}".format(exc), file=sys.stderr)
+    data["server_gid"] = gid
+    data["server_sid"] = sid
+    try:
+        with open(SECRET_FILE, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+    except Exception as exc:
+        print("ERROR: failed to write SSO secret: {}".format(exc), file=sys.stderr)
+        return 1
+    print("OK: SSO secret updated server_gid={} server_sid={}".format(gid, sid))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/postgresql-stack/modules/10-postgresql.sh
+++ b/postgresql-stack/modules/10-postgresql.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Install PostgreSQL server from PGDG (AlmaLinux 9).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_VER="$(cfg_get pg_version)"
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+PG_DATA="$(pg_data_dir)"
+PG_PASS="$(cfg_get pg_superuser_password)"
+APP_USER="$(cfg_get pg_app_user)"
+APP_PASS="$(cfg_get pg_app_password)"
+
+install_pgdg_repo() {
+    if rpm -q pgdg-redhat-repo >/dev/null 2>&1; then
+        log_info "PGDG repo already installed."
+        return 0
+    fi
+    log_info "Installing PGDG repository..."
+    retry 3 5 dnf install -y "https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E '%{rhel}')-$(uname -m)/pgdg-redhat-repo-latest.noarch.rpm"
+    dnf -qy module disable postgresql 2>/dev/null || true
+}
+
+install_packages() {
+    log_info "Installing PostgreSQL ${PG_VER} packages..."
+    retry 3 10 dnf install -y \
+        "postgresql${PG_VER}-server" \
+        "postgresql${PG_VER}-contrib" \
+        "postgresql${PG_VER}"
+    # system_stats powers the pgAdmin Dashboard > System tab.
+    if ! dnf install -y "system_stats_${PG_VER}" 2>/dev/null; then
+        log_warn "system_stats_${PG_VER} package not available; pgAdmin System tab will be limited."
+    fi
+}
+
+create_system_stats_extension() {
+    # Created in the maintenance DB so pgAdmin's Dashboard > System tab works.
+    if ! rpm -q "system_stats_${PG_VER}" >/dev/null 2>&1; then
+        return 0
+    fi
+    log_info "Creating system_stats extension in 'postgres' database..."
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -d postgres -c \
+        "CREATE EXTENSION IF NOT EXISTS system_stats;" || \
+        log_warn "Could not create system_stats extension."
+}
+
+init_database() {
+    if [[ -f "${PG_DATA}/PG_VERSION" ]]; then
+        log_info "PostgreSQL data directory already initialized."
+        return 0
+    fi
+    log_info "Initializing PostgreSQL cluster..."
+    "${PG_BIN}/postgresql-${PG_VER}-setup" initdb
+}
+
+configure_postgresql() {
+    local conf="${PG_DATA}/postgresql.conf"
+    local hba="${PG_DATA}/pg_hba.conf"
+
+    log_info "Configuring PostgreSQL (localhost only)..."
+    if grep -q "^listen_addresses" "${conf}"; then
+        sed -i "s/^#*listen_addresses.*/listen_addresses = 'localhost'/" "${conf}"
+    else
+        echo "listen_addresses = 'localhost'" >> "${conf}"
+    fi
+
+    if ! grep -q "^port" "${conf}"; then
+        echo "port = $(cfg_get pg_port)" >> "${conf}"
+    fi
+
+    # Local peer for postgres OS user; scram for TCP localhost
+    if ! grep -q "postgresql-stack" "${hba}"; then
+        cat >> "${hba}" <<'EOF'
+
+# postgresql-stack
+local   all             postgres                                peer
+host    all             all             127.0.0.1/32            scram-sha-256
+host    all             all             ::1/128                 scram-sha-256
+EOF
+    fi
+}
+
+set_postgres_password() {
+    log_info "Setting postgres superuser password..."
+    systemctl enable "${PG_SVC}"
+    systemctl start "${PG_SVC}"
+    retry 5 3 systemctl is-active --quiet "${PG_SVC}"
+
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -c \
+        "ALTER USER postgres WITH PASSWORD '$(echo "${PG_PASS}" | sed "s/'/''/g")';"
+}
+
+run_bootstrap_sql() {
+    local sql_file="/tmp/postgresql-stack-bootstrap-$$.sql"
+    sed -e "s/__PG_APP_USER__/${APP_USER}/g" \
+        -e "s/__PG_APP_PASSWORD__/$(echo "${APP_PASS}" | sed "s/'/''/g")/g" \
+        "${STACK_ROOT}/sql/bootstrap.sql" > "${sql_file}"
+    chmod 644 "${sql_file}"
+
+    log_info "Running bootstrap SQL..."
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -f "${sql_file}"
+    rm -f "${sql_file}"
+}
+
+install_pgdg_repo
+install_packages
+init_database
+configure_postgresql
+systemctl enable "${PG_SVC}"
+systemctl restart "${PG_SVC}"
+retry 5 3 systemctl is-active --quiet "${PG_SVC}"
+set_postgres_password
+run_bootstrap_sql
+create_system_stats_extension
+
+log_info "PostgreSQL ${PG_VER} is running (localhost only)."

--- a/postgresql-stack/modules/20-pg_cron.sh
+++ b/postgresql-stack/modules/20-pg_cron.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Install and configure pg_cron extension.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_VER="$(cfg_get pg_version)"
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+PG_DATA="$(pg_data_dir)"
+CRON_DB="$(cfg_get pg_cron_database)"
+CONF="$(pg_conf_file)"
+
+install_pg_cron_package() {
+    log_info "Installing pg_cron for PostgreSQL ${PG_VER}..."
+    retry 3 10 dnf install -y "pg_cron_${PG_VER}"
+}
+
+configure_shared_preload() {
+    log_info "Configuring shared_preload_libraries for pg_cron..."
+    if grep -qE "^shared_preload_libraries\s*=" "${CONF}"; then
+        if grep -q "pg_cron" "${CONF}"; then
+            log_info "pg_cron already in shared_preload_libraries."
+        else
+            sed -i -E "s/^shared_preload_libraries\s*=\s*'([^']*)'/shared_preload_libraries = '\1,pg_cron'/" "${CONF}"
+        fi
+    elif grep -qE "^#shared_preload_libraries\s*=" "${CONF}"; then
+        sed -i -E "s/^#shared_preload_libraries\s*=.*/shared_preload_libraries = 'pg_cron'/" "${CONF}"
+    else
+        echo "shared_preload_libraries = 'pg_cron'" >> "${CONF}"
+    fi
+
+    if grep -q "^cron.database_name" "${CONF}"; then
+        sed -i "s/^#*cron.database_name.*/cron.database_name = '${CRON_DB}'/" "${CONF}"
+    else
+        echo "cron.database_name = '${CRON_DB}'" >> "${CONF}"
+    fi
+}
+
+create_extension() {
+    log_info "Creating pg_cron extension in database ${CRON_DB}..."
+    systemctl restart "${PG_SVC}"
+    retry 8 5 systemctl is-active --quiet "${PG_SVC}"
+    sleep 2
+
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -d "${CRON_DB}" -c \
+        "CREATE EXTENSION IF NOT EXISTS pg_cron;"
+}
+
+install_pg_cron_package
+configure_shared_preload
+create_extension
+
+log_info "pg_cron installed and active."

--- a/postgresql-stack/modules/30-pgagent.sh
+++ b/postgresql-stack/modules/30-pgagent.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Optional pgAgent install (deprecated upstream; use pg_cron instead).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_VER="$(cfg_get pg_version)"
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+CRON_DB="$(cfg_get pg_cron_database)"
+
+log_warn "pgAgent is deprecated by the pgAdmin team. Prefer pg_cron (already installed)."
+log_warn "See: https://www.pgadmin.org/download/pgagent-source-code/"
+
+retry 3 10 dnf install -y "pgagent_${PG_VER}" 2>/dev/null || {
+    log_warn "pgagent_${PG_VER} package not found in PGDG; trying pgagent..."
+    retry 3 10 dnf install -y pgagent || {
+        log_error "pgAgent package unavailable. Skipping."
+        exit 0
+    }
+}
+
+if [[ -f /usr/share/pgagent/pgagent.sql ]]; then
+    sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -d "${CRON_DB}" -f /usr/share/pgagent/pgagent.sql 2>/dev/null || \
+        log_warn "pgAgent SQL may already be applied."
+fi
+
+if systemctl list-unit-files | grep -q pgagent; then
+    systemctl enable pgagent 2>/dev/null || true
+    systemctl start pgagent 2>/dev/null || log_warn "pgagent service failed to start; configure manually."
+fi
+
+log_info "pgAgent install step finished (optional component)."

--- a/postgresql-stack/modules/40-pgadmin.sh
+++ b/postgresql-stack/modules/40-pgadmin.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Install pgAdmin4 web and run via gunicorn (systemd).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_EMAIL="$(cfg_get pgadmin_email)"
+PGADMIN_PASS="$(cfg_get pgadmin_password)"
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+PGADMIN_WEB="/usr/pgadmin4/web"
+PGADMIN_VENV="/usr/pgadmin4/venv/bin"
+LOCAL_CFG="${PGADMIN_WEB}/config_local.py"
+# shellcheck source=../lib/pgadmin_env.sh
+source "${STACK_ROOT}/lib/pgadmin_env.sh"
+
+install_pgadmin_repo() {
+    if rpm -q pgadmin4-web >/dev/null 2>&1; then
+        log_info "pgadmin4-web already installed."
+        return 0
+    fi
+    log_info "Installing pgAdmin 4 repository and packages..."
+    if ! rpm -q pgadmin4-redhat-repo >/dev/null 2>&1; then
+        retry 3 5 dnf install -y \
+            "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/yum/pgadmin4-redhat-repo-2-1.noarch.rpm"
+    fi
+    retry 3 10 dnf install -y pgadmin4-web python3-gunicorn
+}
+
+configure_pgadmin_local() {
+    log_info "Writing pgAdmin local config (${LOCAL_CFG})..."
+    cat > "${LOCAL_CFG}" <<EOF
+# Managed by postgresql-stack installer
+DEFAULT_SERVER = '0.0.0.0'
+MASTER_PASSWORD_REQUIRED = False
+WTF_CSRF_ENABLED = True
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+LOG_FILE = '/var/log/pgadmin/pgadmin.log'
+SERVER_MODE = True
+# Disabled so the one-click SSO launcher session is not invalidated when the
+# login (performed server-side over loopback) and the browser present a
+# different IP/User-Agent. Cookies remain Secure + HttpOnly + SameSite=Lax.
+ENHANCED_COOKIE_PROTECTION = False
+ALLOW_SPECIAL_EMAIL_DOMAINS = []
+ALLOW_SPECIAL_EMAIL_ADDRESSES = ['${PGADMIN_EMAIL}']
+EOF
+    chmod 640 "${LOCAL_CFG}"
+    chown root:apache "${LOCAL_CFG}" 2>/dev/null || chmod 644 "${LOCAL_CFG}"
+    mkdir -p /var/log/pgadmin4 /var/log/pgadmin /var/lib/pgadmin
+    chown -R apache:apache /var/log/pgadmin4 /var/log/pgadmin /var/lib/pgadmin 2>/dev/null || true
+    chmod 750 /var/log/pgadmin4 /var/log/pgadmin /var/lib/pgadmin
+}
+
+setup_pgadmin_user() {
+    log_info "Initializing pgAdmin database and admin user..."
+    mkdir -p /var/log/pgadmin /var/lib/pgadmin
+    chown apache:apache /var/log/pgadmin /var/lib/pgadmin 2>/dev/null || true
+    chmod 750 /var/log/pgadmin /var/lib/pgadmin
+
+    export PGADMIN_SETUP_EMAIL="${PGADMIN_EMAIL}"
+    export PGADMIN_SETUP_PASSWORD="${PGADMIN_PASS}"
+
+    local db_ok=0
+    if [[ -f /var/lib/pgadmin/pgadmin4.db ]]; then
+        if pgadmin_python get-users --json >/dev/null 2>&1; then
+            db_ok=1
+            log_info "pgAdmin SQLite DB already exists and is valid."
+        else
+            log_warn "pgAdmin DB invalid; backing up and reinitializing..."
+            mv /var/lib/pgadmin/pgadmin4.db "/var/lib/pgadmin/pgadmin4.db.bak.$(date +%Y%m%d%H%M%S)"
+        fi
+    fi
+
+    if [[ "${db_ok}" -eq 0 ]]; then
+        pgadmin_python setup-db
+        chown apache:apache /var/lib/pgadmin/pgadmin4.db 2>/dev/null || true
+        chmod 600 /var/lib/pgadmin/pgadmin4.db 2>/dev/null || true
+    fi
+
+    if ! pgadmin_python get-users --json 2>/dev/null | grep -q "${PGADMIN_EMAIL}"; then
+        pgadmin_python add-user "${PGADMIN_EMAIL}" "${PGADMIN_PASS}" --admin
+    else
+        log_info "pgAdmin user ${PGADMIN_EMAIL} already exists."
+    fi
+}
+
+install_systemd_unit() {
+    local gunicorn_py="${PGADMIN_VENV}/python3"
+    log_info "Installing pgadmin4.service (gunicorn on ${BIND_HOST}:${BIND_PORT})..."
+    cat > /etc/systemd/system/pgadmin4.service <<EOF
+[Unit]
+Description=pgAdmin 4 web (gunicorn)
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=apache
+Group=apache
+WorkingDirectory=${PGADMIN_WEB}
+Environment=PYTHONPATH=${PGADMIN_WEB}
+ExecStart=${gunicorn_py} -m gunicorn --bind ${BIND_HOST}:${BIND_PORT} --workers 2 --threads 4 --timeout 120 --chdir ${STACK_ROOT}/lib pgadmin_wsgi:application
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctl enable pgadmin4
+    systemctl restart pgadmin4
+    retry 10 5 systemctl is-active --quiet pgadmin4
+}
+
+install_pgadmin_repo
+configure_pgadmin_local
+setup_pgadmin_user
+install_systemd_unit
+
+code="$(curl -sk -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/login" 2>/dev/null || echo 000)"
+if echo "${code}" | grep -qE '200|302|301'; then
+    log_info "pgAdmin responding on http://${BIND_HOST}:${BIND_PORT}/ (HTTP ${code})"
+else
+    log_warn "pgAdmin may still be starting (HTTP ${code}); check: journalctl -u pgadmin4 -n 50"
+fi
+
+log_info "pgAdmin installed. Public URL after proxy: https://${PGADMIN_DOMAIN}/"

--- a/postgresql-stack/modules/45-pgadmin-server.sh
+++ b/postgresql-stack/modules/45-pgadmin-server.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Register the local PostgreSQL server in pgAdmin with a saved password.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_EMAIL="$(cfg_get pgadmin_email)"
+PGADMIN_PASS="$(cfg_get pgadmin_password)"
+PG_SUPER="$(cfg_get pg_superuser)"
+PG_SUPER_PASS="$(cfg_get pg_superuser_password)"
+PG_PORT="$(cfg_get pg_port)"
+PG_VER="$(cfg_get pg_version)"
+SERVER_NAME="PostgreSQL ${PG_VER} (localhost)"
+DISCOVERY_ID="POSTGRESQL_STACK/${PG_VER}"
+
+register_server() {
+    log_info "Registering pgAdmin server '${SERVER_NAME}'..."
+    export PGADMIN_EMAIL="${PGADMIN_EMAIL}"
+    export PGADMIN_PASSWORD="${PGADMIN_PASS}"
+    export PG_SUPERUSER="${PG_SUPER}"
+    export PG_SUPERUSER_PASSWORD="${PG_SUPER_PASS}"
+    export PG_HOST="127.0.0.1"
+    export PG_PORT="${PG_PORT}"
+    export PG_MAINT_DB="postgres"
+    export PG_SERVER_NAME="${SERVER_NAME}"
+    export PG_DISCOVERY_ID="${DISCOVERY_ID}"
+
+    local out
+    if ! out="$(/usr/pgadmin4/venv/bin/python3 "${STACK_ROOT}/lib/register_pg_server.py" 2>&1 | tee -a "${LOG_FILE}")"; then
+        log_error "Failed to register PostgreSQL server in pgAdmin."
+        return 1
+    fi
+    local gid sid
+    gid="$(echo "${out}" | sed -n 's/^SERVER_GID=//p' | tail -1)"
+    sid="$(echo "${out}" | sed -n 's/^SERVER_SID=//p' | tail -1)"
+    if [[ -n "${gid}" && -n "${sid}" ]]; then
+        if /usr/pgadmin4/venv/bin/python3 "${STACK_ROOT}/lib/update_sso_server_ids.py" "${gid}" "${sid}" >>"${LOG_FILE}" 2>&1; then
+            log_info "SSO secret updated with server_gid=${gid} server_sid=${sid}"
+        else
+            log_warn "Could not update SSO secret with server ids (run modules/55-sso.sh after SSO is configured)."
+        fi
+    fi
+}
+
+register_server
+
+count="$(sqlite3 /var/lib/pgadmin/pgadmin4.db "SELECT COUNT(*) FROM server WHERE discovery_id='${DISCOVERY_ID}';" 2>/dev/null || echo 0)"
+if [[ "${count}" -ge 1 ]]; then
+    log_info "OK: pgAdmin has registered server '${SERVER_NAME}'."
+else
+    log_warn "Server row not found after registration; check ${LOG_FILE}"
+fi
+
+# postgres-reg.ini auto-discovery creates passwordless duplicate servers; do not use it.
+if [[ -f /etc/postgres-reg.ini ]] && grep -q "POSTGRESQL_STACK" /etc/postgres-reg.ini 2>/dev/null; then
+    log_info "Removing legacy postgres-reg.ini stack entry (causes duplicate servers)..."
+    sed -i '/\[PostgreSQL\/POSTGRESQL_STACK/,/^$/d' /etc/postgres-reg.ini
+fi
+
+log_info "Server registration complete. After SSO login, pick '${SERVER_NAME}' in Query Tool or connect from the Browser tree."

--- a/postgresql-stack/modules/47-pgadmin-patches.sh
+++ b/postgresql-stack/modules/47-pgadmin-patches.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Patch pgAdmin for Query Tool workspace server dropdown (lazy CSRF API client).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bash "${STACK_ROOT}/lib/apply_pgadmin_patches.sh"

--- a/postgresql-stack/modules/50-subdomain-proxy.sh
+++ b/postgresql-stack/modules/50-subdomain-proxy.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Create CyberPanel child domain and configure LiteSpeed reverse proxy to pgAdmin.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+MASTER_DOMAIN="$(cfg_get master_domain)"
+OWNER="$(cfg_get cyberpanel_owner)"
+PHP_VER="$(cfg_get cyberpanel_php)"
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+DOCROOT="/home/${MASTER_DOMAIN}/${PGADMIN_DOMAIN}"
+VHOST_CONF="/usr/local/lsws/conf/vhosts/${PGADMIN_DOMAIN}/vhost.conf"
+MARKER="# POSTGRESQL_STACK_PROXY"
+
+create_child_domain() {
+    if [[ -f "${VHOST_CONF}" ]]; then
+        log_info "Vhost already exists: ${VHOST_CONF}"
+        return 0
+    fi
+    log_info "Creating child domain ${PGADMIN_DOMAIN} under ${MASTER_DOMAIN}..."
+    retry 3 10 cyberpanel createChild \
+        --masterDomain "${MASTER_DOMAIN}" \
+        --childDomain "${PGADMIN_DOMAIN}" \
+        --owner "${OWNER}" \
+        --php "${PHP_VER}" \
+        --ssl 1 \
+        --path "${PGADMIN_DOMAIN}" || {
+            log_warn "createChild returned non-zero; checking vhost again."
+        }
+    sleep 5
+    if [[ ! -f "${VHOST_CONF}" ]]; then
+        log_error "Failed to create vhost ${VHOST_CONF}. Check CyberPanel owner (${OWNER}) and DNS."
+        exit 1
+    fi
+}
+
+issue_ssl() {
+    log_info "Issuing SSL for ${PGADMIN_DOMAIN}..."
+    retry 3 15 cyberpanel issueSSL --domainName "${PGADMIN_DOMAIN}" || \
+        log_warn "SSL issuance may need DNS propagation; retry later."
+}
+
+write_docroot_htaccess() {
+    mkdir -p "${DOCROOT}/.well-known/acme-challenge"
+    cat > "${DOCROOT}/.htaccess" <<'EOF'
+# postgresql-stack: proxy handled in vhost.conf (ExtProcessor pgadmin4)
+RewriteEngine On
+RewriteCond %{HTTPS} !=on
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+<Files "config.php">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<Files ".env*">
+    Order Allow,Deny
+    Deny from all
+</Files>
+<FilesMatch "\.(log|sql|bak|backup|key|pem|crt|tmp|temp|cache)$">
+    Order Allow,Deny
+    Deny from all
+</FilesMatch>
+EOF
+    chown newst3922:nobody "${DOCROOT}" 2>/dev/null || true
+    find "${DOCROOT}" -exec chown newst3922:newst3922 {} \; 2>/dev/null || true
+    chmod 755 "${DOCROOT}"
+    chmod 644 "${DOCROOT}/.htaccess"
+}
+
+configure_vhost_proxy() {
+    if [[ ! -f "${VHOST_CONF}" ]]; then
+        log_error "Vhost not found: ${VHOST_CONF}. Create domain in CyberPanel first."
+        exit 1
+    fi
+
+    fix_acme_challenge_context
+
+    if grep -q "${MARKER}" "${VHOST_CONF}"; then
+        log_info "Reverse proxy already configured in vhost."
+        return 0
+    fi
+
+    log_info "Patching vhost.conf for pgAdmin reverse proxy..."
+    cp -a "${VHOST_CONF}" "${VHOST_CONF}.bak.postgresql-stack"
+
+    # Remove default PHP scripthandler block if present (proxy replaces it)
+    python3 <<PY
+from pathlib import Path
+import re
+
+path = Path("${VHOST_CONF}")
+text = path.read_text()
+marker = "${MARKER}"
+
+proxy_block = f'''
+{marker}
+extprocessor pgadmin4 {{
+  type                    proxy
+  address                 http://${BIND_HOST}:${BIND_PORT}
+  maxConns                60
+  pcKeepAliveTimeout      -1
+  initTimeout             60
+  retryTimeout            60
+  respBuffer              0
+}}
+
+context / {{
+  type                    proxy
+  handler                 pgadmin4
+  addDefaultCharset       off
+}}
+'''
+
+# Strip existing scripthandler / extprocessor lsapi blocks for clean proxy
+text = re.sub(r'scripthandler\s*\{[^}]*\}\s*', '', text, flags=re.DOTALL)
+text = re.sub(r'extprocessor\s+\w+\s*\{[^}]*type\s+lsapi[^}]*\}\s*', '', text, flags=re.DOTALL)
+
+if 'rewrite  {' in text:
+    text = re.sub(
+        r'rewrite\s*\{[^}]*autoLoadHtaccess\s+1[^}]*\}',
+        'rewrite  {\\n  enable                  1\\n  autoLoadHtaccess        1\\n}',
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+if 'vhssl {' in text:
+    parts = text.split('vhssl {', 1)
+    text = parts[0].rstrip() + '\\n' + proxy_block + '\\nvhssl {' + parts[1]
+else:
+    text = text.rstrip() + '\\n' + proxy_block
+
+path.write_text(text)
+PY
+
+    log_info "vhost.conf updated."
+}
+
+fix_acme_challenge_context() {
+    if [[ ! -f "${VHOST_CONF}" ]]; then
+        return 0
+    fi
+    local challenge_dir="${DOCROOT}/.well-known/acme-challenge"
+    mkdir -p "${challenge_dir}"
+    chmod 755 "${DOCROOT}/.well-known" "${challenge_dir}" 2>/dev/null || true
+    find "${DOCROOT}/.well-known" -exec chown newst3922:newst3922 {} \; 2>/dev/null || true
+
+    TARGET="${VHOST_CONF}" CHALLENGE_DIR="${challenge_dir}" python3 <<'PY'
+import os, re
+from pathlib import Path
+
+path = Path(os.environ["TARGET"])
+challenge_dir = os.environ["CHALLENGE_DIR"]
+text = path.read_text()
+
+block = f'''context /.well-known/acme-challenge {{
+  location                {challenge_dir}
+  allowBrowse             1
+
+  rewrite  {{
+     enable                  0
+  }}
+  addDefaultCharset       off
+
+  phpIniOverride  {{
+
+  }}
+}}'''
+
+if 'context /.well-known/acme-challenge' in text:
+    text = re.sub(
+        r'context /\.well-known/acme-challenge\s*\{.*?\n\}',
+        block,
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+else:
+    anchor = 'rewrite  {'
+    if anchor not in text:
+        raise SystemExit('rewrite block not found in vhost.conf')
+    text = text.replace(anchor, block + '\n\n' + anchor, 1)
+
+path.write_text(text)
+print('acme challenge context updated')
+PY
+    log_info "ACME challenge path set to ${challenge_dir}"
+}
+
+create_child_domain
+write_docroot_htaccess
+configure_vhost_proxy
+issue_ssl
+restart_lsws
+
+log_info "Reverse proxy configured: https://${PGADMIN_DOMAIN}/ -> http://${BIND_HOST}:${BIND_PORT}/"

--- a/postgresql-stack/modules/55-sso.sh
+++ b/postgresql-stack/modules/55-sso.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Configure one-click SSO launcher for pgAdmin.
+# - Generates a per-install SSO token (stored in config.php).
+# - Writes an apache-readable secret file consumed by lib/pgadmin_wsgi.py.
+# - Disables the pgAdmin master-password prompt for frictionless entry.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+SECRET_FILE="/var/lib/pgadmin/.pgstack-sso.json"
+LOCAL_CFG="/usr/pgadmin4/web/config_local.py"
+
+ensure_token() {
+    local token
+    token="$(cfg_get pgadmin_sso_token 2>/dev/null || true)"
+    if [[ -z "${token}" || "${token}" == "missing key" ]]; then
+        token="$(gen_secret 48)"
+        update_config_value "pgadmin_sso_token" "${token}"
+        log_info "Generated new pgAdmin SSO token."
+    else
+        log_info "Existing pgAdmin SSO token preserved."
+    fi
+}
+
+write_secret_file() {
+    local token email pass bhost bport
+    token="$(cfg_get pgadmin_sso_token)"
+    email="$(cfg_get pgadmin_email)"
+    pass="$(cfg_get pgadmin_password)"
+    bhost="$(cfg_get pgadmin_bind_host)"
+    bport="$(cfg_get pgadmin_bind_port)"
+
+    mkdir -p /var/lib/pgadmin
+    TOKEN="${token}" EMAIL="${email}" PASS="${pass}" BHOST="${bhost}" BPORT="${bport}" \
+    SECRET_FILE="${SECRET_FILE}" python3 <<'PY'
+import json, os
+path = os.environ["SECRET_FILE"]
+existing = {}
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        existing = json.load(fh)
+except Exception:
+    pass
+data = {
+    "token": os.environ["TOKEN"],
+    "email": os.environ["EMAIL"],
+    "password": os.environ["PASS"],
+    "backend_host": os.environ.get("BHOST") or "127.0.0.1",
+    "backend_port": int(os.environ.get("BPORT") or 5050),
+}
+for key in ("server_gid", "server_sid"):
+    if key in existing:
+        data[key] = existing[key]
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh)
+PY
+    chown apache:apache "${SECRET_FILE}" 2>/dev/null || true
+    chmod 600 "${SECRET_FILE}"
+    log_info "Wrote SSO secret file (chmod 600, apache-owned): ${SECRET_FILE}"
+}
+
+set_pgadmin_flag() {
+    local key="$1" value="$2"
+    if grep -q "^${key}" "${LOCAL_CFG}"; then
+        sed -i "s/^${key}.*/${key} = ${value}/" "${LOCAL_CFG}"
+    else
+        echo "${key} = ${value}" >> "${LOCAL_CFG}"
+    fi
+}
+
+tune_pgadmin_for_sso() {
+    if [[ ! -f "${LOCAL_CFG}" ]]; then
+        log_warn "pgAdmin config_local.py not found; skipping SSO tuning."
+        return 0
+    fi
+    # Frictionless: no master-password prompt on first/each login.
+    set_pgadmin_flag "MASTER_PASSWORD_REQUIRED" "False"
+    # Required for SSO: the launcher logs in server-side, so the session must not
+    # be bound to the IP/User-Agent (Paranoid/ENHANCED_COOKIE_PROTECTION).
+    set_pgadmin_flag "ENHANCED_COOKIE_PROTECTION" "False"
+    log_info "Tuned pgAdmin for SSO (MASTER_PASSWORD_REQUIRED=False, ENHANCED_COOKIE_PROTECTION=False)."
+}
+
+restart_pgadmin() {
+    log_info "Restarting pgadmin4 to load SSO launcher..."
+    systemctl restart pgadmin4
+    retry 10 5 systemctl is-active --quiet pgadmin4
+}
+
+ensure_token
+write_secret_file
+tune_pgadmin_for_sso
+restart_pgadmin
+
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+TOKEN="$(cfg_get pgadmin_sso_token)"
+sleep 2
+good="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=${TOKEN}" 2>/dev/null || echo 000)"
+bad="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=invalid" 2>/dev/null || echo 000)"
+if [[ "${good}" == "302" ]]; then
+    log_info "OK: SSO launcher auto-login works (HTTP 302 with valid token)."
+else
+    log_warn "SSO launcher returned HTTP ${good} for valid token (expected 302); check journalctl -u pgadmin4."
+fi
+if [[ "${bad}" == "403" ]]; then
+    log_info "OK: SSO launcher rejects invalid token (HTTP 403)."
+else
+    log_warn "SSO launcher returned HTTP ${bad} for invalid token (expected 403)."
+fi
+
+log_info "SSO configured. Tile opens: https://$(cfg_get pgadmin_domain)/sso/?key=<token>"

--- a/postgresql-stack/modules/60-tile.sh
+++ b/postgresql-stack/modules/60-tile.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Inject PostgreSQL/pgAdmin card into CyberPanel Quick App Installer.
+# Target: websiteFunctions/templates/websiteFunctions/website.html (.app-grid).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+SSO_TOKEN="$(cfg_get pgadmin_sso_token 2>/dev/null || true)"
+WEBSITE_HTML="/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/website.html"
+LEGACY_HTML="/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/applicationInstaller.html"
+ICON_DIR="/usr/local/CyberCP/public/static/images/icons"
+ICON_FILE="${ICON_DIR}/postgresql.png"
+MARKER="POSTGRESQL_STACK_TILE"
+if [[ -n "${SSO_TOKEN}" && "${SSO_TOKEN}" != "missing key" ]]; then
+    TILE_URL="https://${PGADMIN_DOMAIN}/sso/?key=${SSO_TOKEN}"
+else
+    TILE_URL="https://${PGADMIN_DOMAIN}/"
+fi
+
+install_icon() {
+    mkdir -p "${ICON_DIR}"
+    if [[ -f "${ICON_FILE}" ]]; then
+        log_info "PostgreSQL icon already present."
+    else
+        log_info "Installing PostgreSQL icon for CyberPanel tile..."
+        if curl -sfL "https://www.postgresql.org/media/img/about/press/elephant.png" -o "${ICON_FILE}.tmp" 2>/dev/null; then
+            mv "${ICON_FILE}.tmp" "${ICON_FILE}"
+            chmod 644 "${ICON_FILE}"
+        else
+            touch "${ICON_FILE}"
+            log_warn "Could not download icon; placeholder created at ${ICON_FILE}."
+        fi
+    fi
+
+    for dest in \
+        "/usr/local/CyberCP/static/images/icons/postgresql.png" \
+        "/usr/local/CyberCP/websiteFunctions/static/images/icons/postgresql.png"; do
+        mkdir -p "$(dirname "${dest}")"
+        cp -f "${ICON_FILE}" "${dest}" 2>/dev/null || true
+    done
+}
+
+clean_legacy_injection() {
+    if [[ -f "${LEGACY_HTML}" ]] && grep -q "${MARKER}" "${LEGACY_HTML}"; then
+        log_info "Removing stale tile from legacy applicationInstaller.html..."
+        TARGET="${LEGACY_HTML}" MARK="${MARKER}" python3 <<'PY'
+import os, re
+from pathlib import Path
+path = Path(os.environ["TARGET"])
+mark = os.environ["MARK"]
+text = path.read_text()
+text = re.sub(r"\n\s*<!-- " + re.escape(mark) + r" -->.*?</a>\n", "\n", text, flags=re.DOTALL)
+path.write_text(text)
+PY
+    fi
+}
+
+patch_website_ui() {
+    if [[ ! -f "${WEBSITE_HTML}" ]]; then
+        return 0
+    fi
+    if grep -q "POSTGRESQL_STACK_UI_FIX" "${WEBSITE_HTML}"; then
+        log_info "Website UI cloak patch already present."
+        return 0
+    fi
+
+    log_info "Patching website.html domain form (hide until Angular, ng-cloak)..."
+    TARGET="${WEBSITE_HTML}" python3 <<'PY'
+from pathlib import Path
+import os
+
+path = Path(os.environ["TARGET"])
+text = path.read_text()
+marker = "<!-- POSTGRESQL_STACK_UI_FIX -->"
+
+old_form = (
+    '<form id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+    '                                  class="form-horizontal bordered-row">'
+)
+new_form = (
+    marker + '\n'
+    '                            <form id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+    '                                  class="form-horizontal bordered-row" style="display:none;" ng-cloak>'
+)
+if old_form in text:
+    text = text.replace(old_form, new_form, 1)
+elif 'POSTGRESQL_STACK_UI_FIX' not in text and 'id="domainCreationForm"' in text:
+    text = text.replace(
+        'id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+        '                                  class="form-horizontal bordered-row"',
+        marker + '\n'
+        '                            <form id="domainCreationForm" name="websiteCreationForm" action="/"\n'
+        '                                  class="form-horizontal bordered-row" style="display:none;" ng-cloak',
+        1,
+    )
+
+old_block = '''                                <div ng-hide="installationProgress" class="form-group">
+                                    <label class="col-sm-2 control-label"></label>
+                                    <div class="col-sm-7">
+
+                                        <div class="alert alert-success text-center">
+                                            <h2>{$ currentStatus $}</h2>
+                                        </div>'''
+new_block = '''                                <div ng-hide="installationProgress" class="form-group" ng-cloak>
+                                    <label class="col-sm-2 control-label"></label>
+                                    <div class="col-sm-7">
+
+                                        <div class="alert alert-success text-center">
+                                            <h2>{$ currentStatus $}</h2>
+                                        </div>'''
+if old_block in text:
+    text = text.replace(old_block, new_block, 1)
+
+for old, new in [
+    ('<div ng-hide="errorMessageBox" class="alert alert-danger">', '<div ng-hide="errorMessageBox" class="alert alert-danger" ng-cloak>'),
+    ('<div ng-hide="success" class="alert alert-success">\n                                            <p>{% trans "Website succesfully created." %}</p>',
+     '<div ng-hide="success" class="alert alert-success" ng-cloak>\n                                            <p>{% trans "Website succesfully created." %}</p>'),
+    ('<div ng-hide="couldNotConnect" class="alert alert-danger">\n                                            <p>{% trans "Could not connect to server. Please refresh this page." %}</p>',
+     '<div ng-hide="couldNotConnect" class="alert alert-danger" ng-cloak>\n                                            <p>{% trans "Could not connect to server. Please refresh this page." %}</p>'),
+]:
+  if old in text:
+    text = text.replace(old, new, 1)
+
+go_back_old = '''                                <div ng-hide="installationProgress" class="form-group">
+                                    <label class="col-sm-3 control-label"></label>
+                                    <div class="col-sm-4">
+                                        <button type="button" ng-disabled="goBackDisable" ng-click="goBack()"'''
+go_back_new = '''                                <div ng-hide="installationProgress" class="form-group" ng-cloak>
+                                    <label class="col-sm-3 control-label"></label>
+                                    <div class="col-sm-4">
+                                        <button type="button" ng-disabled="goBackDisable" ng-click="goBack()"'''
+if go_back_old in text:
+    text = text.replace(go_back_old, go_back_new, 1)
+
+path.write_text(text)
+print("ui patched")
+PY
+}
+
+inject_card() {
+    if [[ ! -f "${WEBSITE_HTML}" ]]; then
+        log_error "CyberPanel website.html not found: ${WEBSITE_HTML}"
+        exit 1
+    fi
+    if grep -q "${MARKER}" "${WEBSITE_HTML}"; then
+        log_info "PostgreSQL card already present in Quick App Installer."
+        return 0
+    fi
+
+    log_info "Injecting PostgreSQL/pgAdmin card into Quick App Installer (website.html)..."
+    cp -a "${WEBSITE_HTML}" "${WEBSITE_HTML}.bak.postgresql-stack.$(date +%Y%m%d%H%M%S)"
+
+    TARGET="${WEBSITE_HTML}" MARK="${MARKER}" TILEURL="${TILE_URL}" python3 <<'PY'
+import os
+from pathlib import Path
+
+path = Path(os.environ["TARGET"])
+mark = os.environ["MARK"]
+url = os.environ["TILEURL"]
+text = path.read_text()
+
+card = (
+    "                <!-- " + mark + " -->\n"
+    "                <a href=\"" + url + "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"app-card postgresql\">\n"
+    "                    <div class=\"quick-badge\">Database</div>\n"
+    "                    <div class=\"app-icon-wrapper\">\n"
+    "                        <img src=\"{% static 'images/icons/postgresql.png' %}\" alt=\"PostgreSQL\" class=\"app-icon\">\n"
+    "                    </div>\n"
+    "                    <h3 class=\"app-name\">PostgreSQL / pgAdmin</h3>\n"
+    "                    <p class=\"app-description\">{% trans \"PostgreSQL database administration via pgAdmin 4\" %}</p>\n"
+    "                    <div class=\"app-features\">\n"
+    "                        <span class=\"feature-tag\">pgAdmin</span>\n"
+    "                        <span class=\"feature-tag\">pg_cron</span>\n"
+    "                        <span class=\"feature-tag\">SQL</span>\n"
+    "                    </div>\n"
+    "                    <div class=\"install-btn\">\n"
+    "                        <i class=\"fas fa-database\"></i>\n"
+    "                        {% trans \"Open pgAdmin\" %}\n"
+    "                    </div>\n"
+    "                </a>\n"
+)
+
+# Insert after the Mautic card (the last card in the Quick App Installer grid).
+# fa-chart-line is unique to the Mautic install button, so this anchors the
+# correct grid rather than the management-tools grid above it.
+anchor = (
+    "                        <i class=\"fas fa-chart-line\"></i>\n"
+    "                        {% trans \"Install Now\" %}\n"
+    "                    </div>\n"
+    "                </a>\n"
+)
+if anchor not in text:
+    raise SystemExit("Mautic card anchor not found in website.html; aborting injection")
+
+text = text.replace(anchor, anchor + card, 1)
+path.write_text(text)
+print("card injected")
+PY
+
+    log_info "Card injected. Re-apply after CyberPanel upgrades: ${STACK_ROOT}/reapply-tile.sh"
+}
+
+update_tile_href() {
+    if [[ ! -f "${WEBSITE_HTML}" ]] || ! grep -q "${MARKER}" "${WEBSITE_HTML}"; then
+        return 0
+    fi
+    TARGET="${WEBSITE_HTML}" MARK="${MARKER}" TILEURL="${TILE_URL}" python3 <<'PY'
+import os, re
+from pathlib import Path
+
+path = Path(os.environ["TARGET"])
+mark = os.environ["MARK"]
+url = os.environ["TILEURL"]
+text = path.read_text()
+
+# Update the href on the tile anchor immediately following our marker comment.
+pattern = re.compile(
+    r'(<!-- ' + re.escape(mark) + r' -->\s*\n\s*<a href=")[^"]*(")'
+)
+new_text, n = pattern.subn(r'\g<1>' + url.replace('\\', r'\\') + r'\g<2>', text, count=1)
+if n and new_text != text:
+    path.write_text(new_text)
+    print("tile href updated")
+else:
+    print("tile href unchanged")
+PY
+}
+
+install_icon
+clean_legacy_injection
+patch_website_ui
+inject_card
+update_tile_href

--- a/postgresql-stack/modules/90-verify.sh
+++ b/postgresql-stack/modules/90-verify.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Post-install verification with retries.
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+load_config
+
+PG_SVC="$(pg_service_name)"
+PG_BIN="$(pg_bin_dir)"
+PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+BIND_HOST="$(cfg_get pgadmin_bind_host)"
+BIND_PORT="$(cfg_get pgadmin_bind_port)"
+CRON_DB="$(cfg_get pg_cron_database)"
+FAIL=0
+
+check_service() {
+    local svc="$1"
+    if systemctl is-active --quiet "${svc}"; then
+        log_info "OK: service ${svc} is active"
+        return 0
+    fi
+    log_error "FAIL: service ${svc} is not active"
+    FAIL=1
+    return 1
+}
+
+check_psql() {
+    if sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -v ON_ERROR_STOP=1 -c 'SELECT 1;' >/dev/null 2>&1; then
+        log_info "OK: psql connects as postgres"
+        return 0
+    fi
+    log_error "FAIL: psql connection failed"
+    FAIL=1
+    return 1
+}
+
+check_pg_cron() {
+    if sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -d "${CRON_DB}" -tAc \
+        "SELECT 1 FROM pg_extension WHERE extname='pg_cron';" 2>/dev/null | grep -q 1; then
+        log_info "OK: pg_cron extension present"
+        return 0
+    fi
+    log_error "FAIL: pg_cron extension missing"
+    FAIL=1
+    return 1
+}
+
+check_system_stats() {
+    if sudo -u postgres env PATH="${PG_BIN}:$PATH" psql -d postgres -tAc \
+        "SELECT 1 FROM pg_extension WHERE extname='system_stats';" 2>/dev/null | grep -q 1; then
+        log_info "OK: system_stats extension present (pgAdmin Dashboard System tab)"
+        return 0
+    fi
+    log_warn "system_stats extension missing; pgAdmin System tab limited (run modules/10-postgresql.sh)"
+    return 0
+}
+
+check_pgadmin_local() {
+    local code
+    code="$(curl -sk -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/login" 2>/dev/null || echo 000)"
+    if echo "${code}" | grep -qE '200|302|301'; then
+        log_info "OK: pgAdmin local backend HTTP ${code}"
+        return 0
+    fi
+    log_error "FAIL: pgAdmin local backend returned HTTP ${code}"
+    FAIL=1
+    return 1
+}
+
+check_pgadmin_server() {
+    local pg_ver count
+    pg_ver="$(cfg_get pg_version)"
+    count="$(sqlite3 /var/lib/pgadmin/pgadmin4.db "SELECT COUNT(*) FROM server WHERE discovery_id='POSTGRESQL_STACK/${pg_ver}';" 2>/dev/null || echo 0)"
+    if [[ "${count}" -ge 1 ]]; then
+        log_info "OK: pgAdmin has registered PostgreSQL server (POSTGRESQL_STACK/${pg_ver})"
+        return 0
+    fi
+    log_error "FAIL: pgAdmin server registration missing (run modules/45-pgadmin-server.sh)"
+    FAIL=1
+    return 1
+}
+
+check_sso() {
+    local token good bad
+    token="$(cfg_get pgadmin_sso_token 2>/dev/null || true)"
+    if [[ -z "${token}" || "${token}" == "missing key" ]]; then
+        log_warn "SSO token not configured; skipping SSO check."
+        return 0
+    fi
+    good="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=${token}" 2>/dev/null || echo 000)"
+    bad="$(curl -s -o /dev/null -w '%{http_code}' "http://${BIND_HOST}:${BIND_PORT}/sso/?key=invalid" 2>/dev/null || echo 000)"
+    if [[ "${good}" == "302" && "${bad}" == "403" ]]; then
+        log_info "OK: SSO auto-login (302 valid token, 403 invalid token)"
+    else
+        log_error "FAIL: SSO check (valid=${good} expected 302, invalid=${bad} expected 403)"
+        FAIL=1
+        return 1
+    fi
+
+    local cj ref csrf hdr gid sid count sess
+    cj="$(mktemp)"
+    ref="https://${PGADMIN_DOMAIN}/browser/"
+    sess="$(curl -sk -H "Host: ${PGADMIN_DOMAIN}" \
+        --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+        -D - "https://${PGADMIN_DOMAIN}/sso/?key=${token}" -o /dev/null 2>/dev/null | \
+        sed -n 's/.*pga4_session=\([^;]*\).*/\1/p' | head -1)"
+    if [[ -z "${sess}" ]]; then
+        log_warn "SSO session cookie not returned; skipping post-login API checks."
+        rm -f "${cj}"
+        return 0
+    fi
+    curl -sk -H "Host: ${PGADMIN_DOMAIN}" -H "Cookie: pga4_session=${sess}" \
+        --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+        "https://${PGADMIN_DOMAIN}/browser/js/utils.js" -o /tmp/pgstack-utils.js 2>/dev/null || true
+    csrf="$(sed -n "s/.*pgAdmin\['csrf_token'\] = '\([^']*\)'.*/\1/p" /tmp/pgstack-utils.js | head -1)"
+    hdr="$(sed -n "s/.*pgAdmin\['csrf_token_header'\] = '\([^']*\)'.*/\1/p" /tmp/pgstack-utils.js | head -1)"
+    if [[ -z "${csrf}" || -z "${hdr}" ]]; then
+        log_warn "SSO session CSRF not available; skipping post-login API checks."
+        rm -f "${cj}"
+        return 0
+    fi
+    gid="$(python3 -c "import json;print(json.load(open('/var/lib/pgadmin/.pgstack-sso.json')).get('server_gid',''))" 2>/dev/null || true)"
+    sid="$(python3 -c "import json;print(json.load(open('/var/lib/pgadmin/.pgstack-sso.json')).get('server_sid',''))" 2>/dev/null || true)"
+    if [[ -n "${gid}" && -n "${sid}" ]]; then
+        local conn_code
+        conn_code="$(curl -sk -H "Host: ${PGADMIN_DOMAIN}" -H "Cookie: pga4_session=${sess}" \
+            -X POST -H "${hdr}: ${csrf}" -H "Referer: ${ref}" -H "Content-Type: application/json" -d '{}' \
+            --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+            "https://${PGADMIN_DOMAIN}/browser/server/connect/${gid}/${sid}" \
+            -o /tmp/pgstack-conn.json -w '%{http_code}' 2>/dev/null || echo 000)"
+        if [[ "${conn_code}" == "200" ]]; then
+            log_info "OK: SSO post-login server connect (gid=${gid} sid=${sid})"
+        else
+            log_warn "SSO post-login connect returned HTTP ${conn_code} (gid=${gid} sid=${sid})"
+        fi
+    fi
+    count="$(curl -sk -H "Host: ${PGADMIN_DOMAIN}" -H "Cookie: pga4_session=${sess}" \
+        -H "${hdr}: ${csrf}" -H "Referer: ${ref}" \
+        --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" \
+        "https://${PGADMIN_DOMAIN}/sqleditor/new_connection_dialog" 2>/dev/null | \
+        python3 -c "import sys,json;d=json.load(sys.stdin);print(len(d.get('data',{}).get('result',{}).get('server_list',{}).get('Servers',[])))" 2>/dev/null || echo 0)"
+    rm -f "${cj}"
+    if [[ "${count}" -ge 1 ]]; then
+        log_info "OK: Query Tool server list API returns ${count} server(s) after SSO"
+        return 0
+    fi
+    log_warn "Query Tool server list API returned 0 servers after SSO"
+    return 0
+}
+
+check_public_url() {
+    local code
+    code="$(curl -sk -o /dev/null -w '%{http_code}' "https://${PGADMIN_DOMAIN}/login" 2>/dev/null || echo 000)"
+    if echo "${code}" | grep -qE '200|302|301'; then
+        log_info "OK: public URL https://${PGADMIN_DOMAIN}/ returned HTTP ${code}"
+        return 0
+    fi
+    code="$(curl -sk -o /dev/null -w '%{http_code}' --resolve "${PGADMIN_DOMAIN}:443:127.0.0.1" "https://${PGADMIN_DOMAIN}/login" 2>/dev/null || echo 000)"
+    if echo "${code}" | grep -qE '200|302|301'; then
+        log_info "OK: reverse proxy via LiteSpeed returned HTTP ${code} (DNS may need A record for ${PGADMIN_DOMAIN})"
+        return 0
+    fi
+    log_warn "Public URL returned HTTP ${code}; add DNS A record for ${PGADMIN_DOMAIN} and re-run: cyberpanel issueSSL --domainName ${PGADMIN_DOMAIN}"
+    return 0
+}
+
+retry 3 5 check_service "${PG_SVC}"
+retry 3 5 check_service pgadmin4
+retry 5 5 check_psql
+retry 3 5 check_pg_cron
+check_system_stats
+retry 8 5 check_pgadmin_local
+retry 3 5 check_pgadmin_server
+retry 3 5 check_sso
+check_public_url
+
+if [[ "${FAIL}" -ne 0 ]]; then
+    log_error "Verification failed. See ${LOG_FILE}"
+    exit 1
+fi
+
+log_info "All critical verification checks passed."

--- a/postgresql-stack/reapply-tile.sh
+++ b/postgresql-stack/reapply-tile.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Re-apply CyberPanel Quick App tile after panel upgrades.
+set -euo pipefail
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${STACK_ROOT}/modules/60-tile.sh"

--- a/postgresql-stack/sql/bootstrap.sql
+++ b/postgresql-stack/sql/bootstrap.sql
@@ -1,0 +1,14 @@
+-- Bootstrap roles for postgresql-stack (run as postgres superuser).
+-- Placeholders __PG_APP_USER__ and __PG_APP_PASSWORD__ are replaced by the installer.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '__PG_APP_USER__') THEN
+        CREATE ROLE __PG_APP_USER__ LOGIN PASSWORD '__PG_APP_PASSWORD__';
+    ELSE
+        ALTER ROLE __PG_APP_USER__ WITH PASSWORD '__PG_APP_PASSWORD__';
+    END IF;
+END
+$$;
+
+GRANT CONNECT ON DATABASE postgres TO __PG_APP_USER__;

--- a/postgresql-stack/uninstall.sh
+++ b/postgresql-stack/uninstall.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Remove PostgreSQL stack (services, tile, optional data purge).
+set -euo pipefail
+
+STACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${STACK_ROOT}/lib/common.sh"
+
+PURGE_DATA=0
+REMOVE_TILE=1
+
+usage() {
+    echo "Usage: $0 [--purge-data] [--keep-tile]"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --purge-data) PURGE_DATA=1; shift ;;
+        --keep-tile) REMOVE_TILE=0; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+require_root
+
+if [[ -f "${CONFIG_PHP}" ]]; then
+    load_config
+    PG_VER="$(cfg_get pg_version)"
+    PGADMIN_DOMAIN="$(cfg_get pgadmin_domain)"
+else
+    PG_VER="17"
+    PGADMIN_DOMAIN="pgadmin.newstargeted.com"
+fi
+
+log_info "Stopping pgAdmin service..."
+systemctl stop pgadmin4 2>/dev/null || true
+systemctl disable pgadmin4 2>/dev/null || true
+rm -f /etc/systemd/system/pgadmin4.service
+systemctl daemon-reload
+
+log_info "Removing SSO secret file..."
+rm -f /var/lib/pgadmin/.pgstack-sso.json
+
+if [[ "${REMOVE_TILE}" -eq 1 ]]; then
+    for html in \
+        "/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/website.html" \
+        "/usr/local/CyberCP/websiteFunctions/templates/websiteFunctions/applicationInstaller.html"; do
+        if [[ -f "${html}" ]] && grep -q "POSTGRESQL_STACK_TILE" "${html}"; then
+            log_info "Removing PostgreSQL card from $(basename "${html}")..."
+            TARGET="${html}" python3 <<'PY'
+import os, re
+from pathlib import Path
+path = Path(os.environ["TARGET"])
+text = path.read_text()
+text = re.sub(r"\n\s*<!-- POSTGRESQL_STACK_TILE -->.*?</a>\n", "\n", text, flags=re.DOTALL)
+path.write_text(text)
+PY
+        fi
+    done
+fi
+
+log_info "PostgreSQL server left installed by default (shared system service)."
+log_info "To remove packages: dnf remove postgresql${PG_VER}-server pgadmin4-web pg_cron_${PG_VER}"
+
+if [[ "${PURGE_DATA}" -eq 1 ]]; then
+    read -r -p "Purge PostgreSQL data directory? This destroys all databases [y/N]: " ans
+    if [[ "${ans}" == "y" || "${ans}" == "Y" ]]; then
+        systemctl stop "postgresql-${PG_VER}" 2>/dev/null || true
+        rm -rf "/var/lib/pgsql/${PG_VER}"
+        log_warn "PostgreSQL data purged."
+    fi
+fi
+
+log_info "Uninstall steps completed. Remove child domain ${PGADMIN_DOMAIN} manually in CyberPanel if desired."

--- a/to-do/POSTGRESQL-STACK.md
+++ b/to-do/POSTGRESQL-STACK.md
@@ -1,0 +1,61 @@
+# PostgreSQL stack (optional addon)
+
+Optional **PostgreSQL 17 + pg_cron + pgAdmin 4** stack for CyberPanel on AlmaLinux/RHEL 9+.
+
+Shipped in-repo at `/usr/local/CyberCP/postgresql-stack/` after panel install or upgrade sync.
+
+## Install (new panel)
+
+Interactive installer:
+
+```bash
+sh <(curl https://cyberpanel.net/install.sh || wget -O - https://cyberpanel.net/install.sh)
+```
+
+Answer **Yes** when asked about the PostgreSQL stack, or use:
+
+```bash
+sh cyberpanel.sh --postgresql-stack
+```
+
+## Install (existing server, manual)
+
+From the live panel tree:
+
+```bash
+cd /usr/local/CyberCP/postgresql-stack
+./install.sh --master-domain example.com --domain pgadmin.example.com
+```
+
+Secrets are written to `config.php` (chmod 600, not in git).
+
+## Upgrade
+
+On upgrade, if `config.php` already exists the upgrade script:
+
+1. Keeps existing secrets
+2. Refreshes pgAdmin patches and the CyberPanel Quick App tile
+3. Restarts `pgadmin4` if the unit is installed
+
+Fresh optional install after upgrade:
+
+```bash
+/usr/local/CyberCP/postgresql-stack/install.sh
+```
+
+## Uninstall
+
+```bash
+/usr/local/CyberCP/postgresql-stack/uninstall.sh
+```
+
+Use `--purge-data` only when you intend to remove PostgreSQL data.
+
+## Branches
+
+| Branch | Status |
+|--------|--------|
+| `v3.0.5-dev` | Integrated in `cyberpanel.sh` and `cyberpanel_upgrade.sh` |
+| `v3.0.4` | Stack files included; manual or `--postgresql-stack` install |
+
+Fork reference: [master3395/cyberpanel v3.0.4](https://github.com/master3395/cyberpanel/tree/v3.0.4)


### PR DESCRIPTION
## Summary

Fixes Cloudflare DNS/SSL integration so API Tokens work (including when an email field is also saved), and fixes an `IndentationError` in `cloudManager.py` that 500'd authenticated pages.

Replaces part of #1901 (Cloudflare portion). Keep #1901 open as reference. Base: `usmannasir:v3.0.4-dev` (`24b648f2`).

## Changes

### Fixes

- Add `DNS.createCloudFlareClient(email, api_secret)` distinguishing Global API Key vs API Token
- Route `dnsManager`, `dnsUtilities`, `sslv2`, and `cloudManager` through the helper
- Move `from plogical.dnsUtilities import DNS` to module top-level in `cloudManager.py` (fixes IndentationError)

### Updates

- Token markers / non-email / non-37-hex secrets use `CloudFlare(token=...)`
- Classic 37-char hex + email continues to use email+key auth

## Tests / smoke

| Check | Result |
|-------|--------|
| `py_compile` on touched Cloudflare/DNS Python | PASS |
| Live Cloudflare DNS/SSL with API Token | NOT RUN |
| Live Cloudflare Global API Key path | NOT RUN |
| Docker / Hyper-V smoke | SKIPPED (no Docker CLI) |

Environment: Windows Cursor Local, 27/08/2026.

## Out of scope

- Installer/EL10
- fail2ban / autoBan / pluginHolder store UI
- Activity Board / SnappyMail favicon (not included; keep Cloudflare-only)
