### PR TITLE
feat(backup): restore preview and confirmation before submitRestore

### DIFF
--- a/backup/backupManager.py
+++ b/backup/backupManager.py
@@ -821,17 +821,16 @@ class BackupManager:
             restore_in_progress = 0
             restore_state = ''
             backup_dir = archive_path_without_suffix(backupFile)
-            status_path = os.path.join("/home", "backup", backup_dir)
-            if os.path.exists(status_path):
+            status_file = os.path.join("/home", "backup", backup_dir, "status")
+            if os.path.isfile(status_file):
                 try:
-                    execPath = "sudo cat " + shlex.quote(status_path + "/status")
+                    execPath = "sudo cat " + shlex.quote(status_file)
                     status = ProcessUtilities.outputExecutioner(execPath)
                     if status.find("Done") == -1 and status.find("[5009]") == -1:
                         restore_in_progress = 1
                         restore_state = status
                 except BaseException:
-                    restore_in_progress = 1
-                    restore_state = 'Unknown'
+                    pass
 
             final_json = json.dumps({
                 'infoStatus': 1,

--- a/backup/backupManager.py
+++ b/backup/backupManager.py
@@ -688,6 +688,15 @@ class BackupManager:
 
     def submitRestore(self, data=None, userID=None):
         try:
+            confirmed = data.get('confirmed')
+            if confirmed not in (True, 1, '1', 'true', 'True'):
+                final_dic = {
+                    'restoreStatus': 0,
+                    'error_message': 'Restore confirmation required. Review the backup details and confirm before starting.'
+                }
+                final_json = json.dumps(final_dic)
+                return HttpResponse(final_json)
+
             backupFile = data['backupFile']
             originalFile = "/home/backup/" + backupFile
 
@@ -780,6 +789,64 @@ class BackupManager:
             final_dic = {'restoreStatus': 0, 'error_message': str(msg), 'abort': 0, 'running': 'Running..', 'status': ''}
             final_json = json.dumps(final_dic)
             return HttpResponse(final_json)
+
+    def getBackupFileInfo(self, data=None, userID=None):
+        try:
+            backupFile = data.get('backupFile', '')
+            if not backupFile or '..' in str(backupFile):
+                return ACLManager.loadErrorJson('infoStatus', 0)
+
+            currentACL = ACLManager.loadedACL(userID)
+            if currentACL['admin'] != 1:
+                return ACLManager.loadErrorJson('infoStatus', 0)
+
+            file_path = os.path.join("/home", "backup", backupFile)
+            if not os.path.isfile(file_path):
+                final_dic = {'infoStatus': 0, 'error_message': 'Backup file not found.'}
+                return HttpResponse(json.dumps(final_dic))
+
+            stat = os.stat(file_path)
+            size_bytes = stat.st_size
+            modified_display = time.strftime("%d/%m/%Y %H:%M", time.localtime(stat.st_mtime))
+
+            if size_bytes >= 1073741824:
+                size_display = "%.2f GB" % (size_bytes / 1073741824.0)
+            elif size_bytes >= 1048576:
+                size_display = "%.2f MB" % (size_bytes / 1048576.0)
+            elif size_bytes >= 1024:
+                size_display = "%.2f KB" % (size_bytes / 1024.0)
+            else:
+                size_display = "%d bytes" % size_bytes
+
+            restore_in_progress = 0
+            restore_state = ''
+            backup_dir = archive_path_without_suffix(backupFile)
+            status_path = os.path.join("/home", "backup", backup_dir)
+            if os.path.exists(status_path):
+                try:
+                    execPath = "sudo cat " + shlex.quote(status_path + "/status")
+                    status = ProcessUtilities.outputExecutioner(execPath)
+                    if status.find("Done") == -1 and status.find("[5009]") == -1:
+                        restore_in_progress = 1
+                        restore_state = status
+                except BaseException:
+                    restore_in_progress = 1
+                    restore_state = 'Unknown'
+
+            final_json = json.dumps({
+                'infoStatus': 1,
+                'error_message': 'None',
+                'fileName': backupFile,
+                'fileSize': size_display,
+                'fileSizeBytes': size_bytes,
+                'modified': modified_display,
+                'restoreInProgress': restore_in_progress,
+                'restoreState': restore_state,
+            })
+            return HttpResponse(final_json)
+        except BaseException as msg:
+            final_dic = {'infoStatus': 0, 'error_message': str(msg)}
+            return HttpResponse(json.dumps(final_dic))
 
     def backupDestinations(self, request=None, userID=None, data=None):
         proc = httpProc(request, 'backup/backupDestinations.html', {}, 'addDeleteDestinations')

--- a/backup/static/backup/backup.js
+++ b/backup/static/backup/backup.js
@@ -562,7 +562,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
     $scope.runningRestore = true;
     $scope.restoreButton = true;
     $scope.backupPreview = true;
-    $scope.confirmModal = true;
+    $scope.showConfirmModal = false;
     $scope.confirmChecked = false;
     $scope.restoreFinished = false;
     $scope.couldNotConnect = true;
@@ -580,7 +580,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
         $scope.restoreFinished = false;
         $scope.backupError = true;
         $scope.confirmChecked = false;
-        $scope.confirmModal = true;
+        $scope.showConfirmModal = false;
         $scope.restoreInProgress = false;
         $scope.previewDetails = null;
         if (restorePollTimer) {
@@ -642,11 +642,11 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
             return;
         }
         $scope.confirmChecked = false;
-        $scope.confirmModal = false;
+        $scope.showConfirmModal = true;
     };
 
     $scope.cancelRestoreConfirm = function () {
-        $scope.confirmModal = true;
+        $scope.showConfirmModal = false;
         $scope.confirmChecked = false;
     };
 
@@ -716,7 +716,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
             return;
         }
 
-        $scope.confirmModal = true;
+        $scope.showConfirmModal = false;
         var restoreBackupButton = document.getElementById("restoreBackup");
         if (restoreBackupButton) {
             restoreBackupButton.disabled = true;

--- a/backup/static/backup/backup.js
+++ b/backup/static/backup/backup.js
@@ -561,21 +561,94 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
     $scope.restoreLoading = true;
     $scope.runningRestore = true;
     $scope.restoreButton = true;
+    $scope.backupPreview = true;
+    $scope.confirmModal = true;
+    $scope.confirmChecked = false;
     $scope.restoreFinished = false;
     $scope.couldNotConnect = true;
     $scope.backupError = true;
     $scope.siteExists = true;
+    $scope.previewLoading = true;
+    $scope.restoreInProgress = false;
 
-    // check to start time of status function
+    var restorePollTimer = null;
 
-    var check = 1;
-
+    function resetSelectionState() {
+        $scope.backupPreview = true;
+        $scope.restoreButton = true;
+        $scope.runningRestore = true;
+        $scope.restoreFinished = false;
+        $scope.backupError = true;
+        $scope.confirmChecked = false;
+        $scope.confirmModal = true;
+        $scope.restoreInProgress = false;
+        $scope.previewDetails = null;
+        if (restorePollTimer) {
+            $timeout.cancel(restorePollTimer);
+            restorePollTimer = null;
+        }
+    }
 
     $scope.fetchDetails = function () {
+        resetSelectionState();
+
+        if (!$scope.backupFile) {
+            $scope.restoreLoading = true;
+            $scope.previewLoading = true;
+            return;
+        }
+
         $scope.restoreLoading = false;
-        getRestoreStatus();
+        $scope.previewLoading = false;
+
+        var url = "/backup/getBackupFileInfo";
+        var data = {
+            backupFile: $scope.backupFile,
+        };
+        var config = {
+            headers: {
+                'X-CSRFToken': getCookie('csrftoken')
+            }
+        };
+
+        $http.post(url, data, config).then(function (response) {
+            $scope.previewLoading = true;
+            if (response.data.infoStatus === 1) {
+                $scope.previewDetails = response.data;
+                $scope.backupPreview = false;
+                $scope.backupError = true;
+                if (response.data.restoreInProgress === 1) {
+                    $scope.restoreInProgress = true;
+                    $scope.runningRestore = false;
+                    $scope.running = "Running..";
+                    $scope.fileName = response.data.fileName;
+                    $scope.status = response.data.restoreState || "In progress";
+                    getRestoreStatus();
+                } else {
+                    $scope.restoreButton = false;
+                }
+            } else {
+                $scope.backupError = false;
+                $scope.errorMessage = response.data.error_message;
+            }
+        }, function () {
+            $scope.previewLoading = true;
+            $scope.couldNotConnect = false;
+        });
     };
 
+    $scope.openRestoreConfirm = function () {
+        if (!$scope.backupFile || !$scope.previewDetails || $scope.restoreInProgress) {
+            return;
+        }
+        $scope.confirmChecked = false;
+        $scope.confirmModal = false;
+    };
+
+    $scope.cancelRestoreConfirm = function () {
+        $scope.confirmModal = true;
+        $scope.confirmChecked = false;
+    };
 
     function getRestoreStatus() {
 
@@ -608,9 +681,13 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
                     $scope.restoreLoading = true;
                     $scope.status = response.data.status;
                     $scope.runningRestore = false;
-                    $scope.restoreButton = false;
+                    $scope.restoreButton = true;
                     $scope.restoreFinished = true;
-                    $timeout.cancel();
+                    $scope.restoreInProgress = false;
+                    if (restorePollTimer) {
+                        $timeout.cancel(restorePollTimer);
+                        restorePollTimer = null;
+                    }
                     return;
                 } else {
                     $scope.running = response.data.running;
@@ -619,7 +696,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
                     $scope.status = response.data.status;
                     $scope.runningRestore = false;
                     $scope.restoreButton = true;
-                    $timeout(getRestoreStatus, 2000);
+                    restorePollTimer = $timeout(getRestoreStatus, 2000);
                 }
             }
 
@@ -635,8 +712,15 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
 
 
     $scope.restoreBackup = function () {
+        if (!$scope.confirmChecked) {
+            return;
+        }
+
+        $scope.confirmModal = true;
         var restoreBackupButton = document.getElementById("restoreBackup");
-        restoreBackupButton.disabled = true;
+        if (restoreBackupButton) {
+            restoreBackupButton.disabled = true;
+        }
         var backupFile = $scope.backupFile;
         $scope.running = "Lets start.."
 
@@ -644,6 +728,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
 
         var data = {
             backupFile: backupFile,
+            confirmed: true,
         };
 
         var config = {
@@ -664,20 +749,28 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
                 $scope.running = "Running";
                 $scope.fileName = $scope.backupFile;
                 $scope.status = "Just Started..";
+                $scope.restoreInProgress = true;
+                $scope.restoreButton = true;
 
                 getRestoreStatus();
-                restoreBackupButton.disabled = false;
+                if (restoreBackupButton) {
+                    restoreBackupButton.disabled = false;
+                }
             } else {
                 $scope.backupError = false;
                 $scope.errorMessage = response.data.error_message;
-                restoreBackupButton.disabled = false;
+                if (restoreBackupButton) {
+                    restoreBackupButton.disabled = false;
+                }
             }
 
         }
 
         function cantLoadInitialDatas(response) {
             $scope.couldNotConnect = false;
-            restoreBackupButton.disabled = false;
+            if (restoreBackupButton) {
+                restoreBackupButton.disabled = false;
+            }
         }
 
     };

--- a/backup/static/backup/backup.js
+++ b/backup/static/backup/backup.js
@@ -559,7 +559,7 @@ app.controller('backupWebsiteControl', function ($scope, $http, $timeout) {
 app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
 
     $scope.restoreLoading = true;
-    $scope.runningRestore = true;
+    $scope.showRestoreProgress = false;
     $scope.restoreButton = true;
     $scope.backupPreview = true;
     $scope.showConfirmModal = false;
@@ -576,7 +576,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
     function resetSelectionState() {
         $scope.backupPreview = true;
         $scope.restoreButton = true;
-        $scope.runningRestore = true;
+        $scope.showRestoreProgress = false;
         $scope.restoreFinished = false;
         $scope.backupError = true;
         $scope.confirmChecked = false;
@@ -619,7 +619,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
                 $scope.backupError = true;
                 if (response.data.restoreInProgress === 1) {
                     $scope.restoreInProgress = true;
-                    $scope.runningRestore = false;
+                    $scope.showRestoreProgress = true;
                     $scope.running = "Running..";
                     $scope.fileName = response.data.fileName;
                     $scope.status = response.data.restoreState || "In progress";
@@ -680,7 +680,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
                     $scope.fileName = $scope.backupFile;
                     $scope.restoreLoading = true;
                     $scope.status = response.data.status;
-                    $scope.runningRestore = false;
+                    $scope.showRestoreProgress = false;
                     $scope.restoreButton = true;
                     $scope.restoreFinished = true;
                     $scope.restoreInProgress = false;
@@ -694,7 +694,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
                     $scope.fileName = $scope.backupFile;
                     $scope.restoreLoading = false;
                     $scope.status = response.data.status;
-                    $scope.runningRestore = false;
+                    $scope.showRestoreProgress = true;
                     $scope.restoreButton = true;
                     restorePollTimer = $timeout(getRestoreStatus, 2000);
                 }
@@ -745,7 +745,7 @@ app.controller('restoreWebsiteControl', function ($scope, $http, $timeout) {
 
             $scope.restoreLoading = true;
             if (response.data.restoreStatus == 1) {
-                $scope.runningRestore = false;
+                $scope.showRestoreProgress = true;
                 $scope.running = "Running";
                 $scope.fileName = $scope.backupFile;
                 $scope.status = "Just Started..";

--- a/backup/templates/backup/restore.html
+++ b/backup/templates/backup/restore.html
@@ -603,7 +603,7 @@
                 </div>
 
                 <!-- Restore Progress -->
-                <div ng-hide="runningRestore" class="restore-progress-card">
+                <div ng-if="showRestoreProgress" class="restore-progress-card">
                     <div class="progress-status">
                         <div class="status-info">
                             <div class="status-icon">

--- a/backup/templates/backup/restore.html
+++ b/backup/templates/backup/restore.html
@@ -119,6 +119,117 @@
         transform: translateY(-2px);
         box-shadow: 0 4px 12px rgba(91, 95, 207, 0.2);
     }
+
+    .btn-danger {
+        background: #dc3545;
+        color: white;
+        border: none;
+        padding: 0.75rem 2rem;
+        border-radius: 10px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+    }
+
+    .btn-danger:hover {
+        background: #bb2d3b;
+    }
+
+    .btn-danger:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+    }
+
+    .backup-preview-card {
+        background: var(--bg-secondary, #f8f9ff);
+        border: 1px solid var(--border-primary, #e8e9ff);
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-top: 1.5rem;
+    }
+
+    .preview-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+    }
+
+    .preview-table th,
+    .preview-table td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border-primary, #e8e9ff);
+        font-size: 0.875rem;
+    }
+
+    .preview-table th {
+        width: 180px;
+        color: var(--text-secondary, #64748b);
+        font-weight: 600;
+    }
+
+    .preview-warning {
+        background: #fff3cd;
+        border: 1px solid #ffeaa7;
+        border-radius: 10px;
+        padding: 1rem 1.25rem;
+        margin-top: 1rem;
+        color: #856404;
+        font-size: 0.875rem;
+    }
+
+    .confirm-modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.55);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 10000;
+        padding: 1rem;
+    }
+
+    .confirm-modal {
+        background: var(--bg-primary, #fff);
+        border-radius: 16px;
+        max-width: 560px;
+        width: 100%;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+        overflow: hidden;
+    }
+
+    .confirm-modal-header {
+        padding: 1.25rem 1.5rem;
+        border-bottom: 1px solid var(--border-primary, #e8e9ff);
+        background: #fff3cd;
+    }
+
+    .confirm-modal-body {
+        padding: 1.5rem;
+    }
+
+    .confirm-modal-actions {
+        display: flex;
+        gap: 0.75rem;
+        justify-content: flex-end;
+        padding: 0 1.5rem 1.5rem;
+        flex-wrap: wrap;
+    }
+
+    .confirm-checkbox {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+        margin-top: 1rem;
+        font-size: 0.875rem;
+        color: var(--text-primary, #1e293b);
+    }
     
     .main-card {
         background: var(--bg-primary, white);
@@ -421,12 +532,73 @@
                             {% endfor %}
                         </select>
                     </div>
+
+                    <div ng-hide="previewLoading" style="text-align: center; margin-top: 1rem;">
+                        <span class="loading-spinner"></span>
+                        <span style="margin-left: 0.5rem; color: var(--text-secondary, #64748b); font-size: 0.875rem;">{% trans "Loading backup details..." %}</span>
+                    </div>
+
+                    <div ng-hide="backupPreview" class="backup-preview-card">
+                        <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: var(--text-primary, #1e293b);">
+                            <i class="fas fa-list-alt" style="margin-right: 0.5rem;"></i>
+                            {% trans "Selected Backup Details" %}
+                        </h3>
+                        <table class="preview-table">
+                            <tbody>
+                                <tr>
+                                    <th>{% trans "File name" %}</th>
+                                    <td><span class="file-badge">{$ previewDetails.fileName $}</span></td>
+                                </tr>
+                                <tr>
+                                    <th>{% trans "File size" %}</th>
+                                    <td>{$ previewDetails.fileSize $}</td>
+                                </tr>
+                                <tr>
+                                    <th>{% trans "Last modified" %}</th>
+                                    <td>{$ previewDetails.modified $}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <div class="preview-warning">
+                            <i class="fas fa-exclamation-triangle"></i>
+                            {% trans "Review these details carefully. Restoring the wrong backup can overwrite live website data." %}
+                        </div>
+                    </div>
                     
                     <div ng-hide="restoreButton" style="text-align: center; margin-top: 2rem;">
-                        <button type="button" ng-click="restoreBackup()" id="restoreBackup" class="btn-primary">
-                            <i class="fas fa-sync-alt"></i>
-                            {% trans "Start Restoration" %}
+                        <button type="button" ng-click="openRestoreConfirm()" id="restoreBackup" class="btn-primary">
+                            <i class="fas fa-shield-alt"></i>
+                            {% trans "Review and Restore" %}
                         </button>
+                    </div>
+                </div>
+
+                <div ng-hide="confirmModal" class="confirm-modal-backdrop">
+                    <div class="confirm-modal">
+                        <div class="confirm-modal-header">
+                            <h3 style="margin: 0; font-size: 1.1rem; color: #856404;">
+                                <i class="fas fa-exclamation-triangle"></i>
+                                {% trans "Confirm website restore" %}
+                            </h3>
+                        </div>
+                        <div class="confirm-modal-body">
+                            <p>{% trans "You are about to restore this backup:" %}</p>
+                            <p><strong>{$ previewDetails.fileName $}</strong> ({$ previewDetails.fileSize $}, {$ previewDetails.modified $})</p>
+                            <p>{% trans "This action can replace databases, files, and mail settings for the restored website. It cannot be undone easily." %}</p>
+                            <label class="confirm-checkbox">
+                                <input type="checkbox" ng-model="confirmChecked">
+                                <span>{% trans "I have verified this is the correct backup and I want to start the restore now." %}</span>
+                            </label>
+                        </div>
+                        <div class="confirm-modal-actions">
+                            <button type="button" class="btn-secondary" ng-click="cancelRestoreConfirm()">
+                                {% trans "Cancel" %}
+                            </button>
+                            <button type="button" class="btn-danger" ng-click="restoreBackup()" ng-disabled="!confirmChecked">
+                                <i class="fas fa-sync-alt"></i>
+                                {% trans "Yes, start restore" %}
+                            </button>
+                        </div>
                     </div>
                 </div>
 

--- a/backup/templates/backup/restore.html
+++ b/backup/templates/backup/restore.html
@@ -533,12 +533,12 @@
                         </select>
                     </div>
 
-                    <div ng-hide="previewLoading" style="text-align: center; margin-top: 1rem;">
+                    <div ng-if="!previewLoading && backupFile" style="text-align: center; margin-top: 1rem;">
                         <span class="loading-spinner"></span>
                         <span style="margin-left: 0.5rem; color: var(--text-secondary, #64748b); font-size: 0.875rem;">{% trans "Loading backup details..." %}</span>
                     </div>
 
-                    <div ng-hide="backupPreview" class="backup-preview-card">
+                    <div ng-if="previewDetails" class="backup-preview-card">
                         <h3 style="margin: 0 0 0.5rem; font-size: 1rem; color: var(--text-primary, #1e293b);">
                             <i class="fas fa-list-alt" style="margin-right: 0.5rem;"></i>
                             {% trans "Selected Backup Details" %}
@@ -573,7 +573,7 @@
                     </div>
                 </div>
 
-                <div ng-hide="confirmModal" class="confirm-modal-backdrop">
+                <div ng-if="showConfirmModal" class="confirm-modal-backdrop">
                     <div class="confirm-modal">
                         <div class="confirm-modal-header">
                             <h3 style="margin: 0; font-size: 1.1rem; color: #856404;">

--- a/backup/test_restore_preview.py
+++ b/backup/test_restore_preview.py
@@ -47,11 +47,13 @@ class RestorePreviewTests(unittest.TestCase):
         backup_name = 'example.com-backup.tar.gz'
         fake_stat = mock.Mock(st_size=1048576, st_mtime=1700000000.0)
 
+        def isfile(path):
+            return path.endswith('.tar.gz')
+
         with mock.patch('backup.backupManager.ACLManager.loadedACL', return_value={'admin': 1}), mock.patch(
-            'backup.backupManager.os.path.isfile', return_value=True
+            'backup.backupManager.os.path.isfile', side_effect=isfile
         ), mock.patch('backup.backupManager.os.stat', return_value=fake_stat), mock.patch(
-            'backup.backupManager.os.path.exists', return_value=False
-        ), mock.patch('backup.backupManager.time.strftime', return_value='15/11/2023 09:46'):
+            'backup.backupManager.time.strftime', return_value='15/11/2023 09:46'):
             response = BackupManager().getBackupFileInfo(
                 data={'backupFile': backup_name},
                 userID=1,
@@ -94,6 +96,26 @@ class RestorePreviewTests(unittest.TestCase):
         self.assertIn('/backup/getBackupFileInfo', source)
         self.assertIn('openRestoreConfirm', source)
         self.assertIn('confirmed: true', source)
+
+
+    def test_get_backup_file_info_ignores_extract_dir_without_status(self):
+        backup_name = 'example.com-backup.tar.gz'
+        fake_stat = mock.Mock(st_size=2048, st_mtime=1700000000.0)
+
+        def isfile(path):
+            return path.endswith('.tar.gz')
+
+        with mock.patch('backup.backupManager.ACLManager.loadedACL', return_value={'admin': 1}), mock.patch(
+            'backup.backupManager.os.path.isfile', side_effect=isfile
+        ), mock.patch('backup.backupManager.os.stat', return_value=fake_stat):
+            response = BackupManager().getBackupFileInfo(
+                data={'backupFile': backup_name},
+                userID=1,
+            )
+
+        payload = json.loads(response.content)
+        self.assertEqual(1, payload['infoStatus'])
+        self.assertEqual(0, payload['restoreInProgress'])
 
 
 if __name__ == '__main__':

--- a/backup/test_restore_preview.py
+++ b/backup/test_restore_preview.py
@@ -1,0 +1,100 @@
+import json
+import os
+import unittest
+from unittest import mock
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CyberCP.settings')
+
+import django
+
+django.setup()
+
+from backup.backupManager import BackupManager
+
+
+class RestorePreviewTests(unittest.TestCase):
+
+    def test_submit_restore_requires_confirmation(self):
+        with mock.patch('backup.backupManager.ACLManager.loadedACL', return_value={'admin': 1}):
+            response = BackupManager().submitRestore(
+                data={'backupFile': 'example.com-backup.tar.gz'},
+                userID=1,
+            )
+
+        payload = json.loads(response.content)
+        self.assertEqual(0, payload['restoreStatus'])
+        self.assertIn('confirmation required', payload['error_message'])
+
+    def test_submit_restore_accepts_confirmed_flag(self):
+        with mock.patch('backup.backupManager.ACLManager.loadedACL', return_value={'admin': 1}), mock.patch(
+            'backup.backupManager.os.path.exists', return_value=True
+        ), mock.patch('backup.backupManager.ProcessUtilities.popenExecutioner') as popen_mock, mock.patch(
+            'backup.backupManager.time.sleep'
+        ):
+            response = BackupManager().submitRestore(
+                data={
+                    'backupFile': 'example.com-backup.tar.gz',
+                    'confirmed': True,
+                },
+                userID=1,
+            )
+
+        payload = json.loads(response.content)
+        self.assertEqual(1, payload['restoreStatus'])
+        popen_mock.assert_called_once()
+
+    def test_get_backup_file_info_returns_metadata(self):
+        backup_name = 'example.com-backup.tar.gz'
+        fake_stat = mock.Mock(st_size=1048576, st_mtime=1700000000.0)
+
+        with mock.patch('backup.backupManager.ACLManager.loadedACL', return_value={'admin': 1}), mock.patch(
+            'backup.backupManager.os.path.isfile', return_value=True
+        ), mock.patch('backup.backupManager.os.stat', return_value=fake_stat), mock.patch(
+            'backup.backupManager.os.path.exists', return_value=False
+        ), mock.patch('backup.backupManager.time.strftime', return_value='15/11/2023 09:46'):
+            response = BackupManager().getBackupFileInfo(
+                data={'backupFile': backup_name},
+                userID=1,
+            )
+
+        payload = json.loads(response.content)
+        self.assertEqual(1, payload['infoStatus'])
+        self.assertEqual(backup_name, payload['fileName'])
+        self.assertEqual('1.00 MB', payload['fileSize'])
+        self.assertEqual('15/11/2023 09:46', payload['modified'])
+        self.assertEqual(0, payload['restoreInProgress'])
+
+    def test_get_backup_file_info_rejects_path_traversal(self):
+        with mock.patch('backup.backupManager.ACLManager.loadErrorJson', return_value=mock.Mock(content=b'{"infoStatus":0}')):
+            response = BackupManager().getBackupFileInfo(
+                data={'backupFile': '../etc/passwd.tar.gz'},
+                userID=1,
+            )
+
+        self.assertEqual(b'{"infoStatus":0}', response.content)
+
+    def test_restore_template_includes_confirmation_flow(self):
+        template_path = os.path.join(
+            os.path.dirname(__file__), 'templates', 'backup', 'restore.html'
+        )
+        with open(template_path, encoding='utf-8') as template:
+            source = template.read()
+
+        self.assertIn('Selected Backup Details', source)
+        self.assertIn('Review and Restore', source)
+        self.assertIn('Confirm website restore', source)
+        self.assertIn('Yes, start restore', source)
+        self.assertIn('ng-click="openRestoreConfirm()"', source)
+
+    def test_restore_js_uses_preview_endpoint_and_confirmed_flag(self):
+        js_path = os.path.join(os.path.dirname(__file__), 'static', 'backup', 'backup.js')
+        with open(js_path, encoding='utf-8') as js_file:
+            source = js_file.read()
+
+        self.assertIn('/backup/getBackupFileInfo', source)
+        self.assertIn('openRestoreConfirm', source)
+        self.assertIn('confirmed: true', source)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backup/urls.py
+++ b/backup/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     re_path(r'^deleteBackup$', views.deleteBackup, name='deleteBackup'),
 
     re_path(r'^restoreStatus$', views.restoreStatus, name='restoreStatus'),
+    re_path(r'^getBackupFileInfo$', views.getBackupFileInfo, name='getBackupFileInfo'),
 
     re_path(r'^submitRestore$', views.submitRestore, name='submitRestore'),
 

--- a/backup/views.py
+++ b/backup/views.py
@@ -201,6 +201,15 @@ def restoreStatus(request):
         return redirect(loadLoginPage)
 
 
+def getBackupFileInfo(request):
+    try:
+        userID = request.session['userID']
+        wm = BackupManager()
+        return wm.getBackupFileInfo(json.loads(request.body), userID)
+    except KeyError:
+        return redirect(loadLoginPage)
+
+
 def backupDestinations(request):
     try:
         userID = request.session['userID']

--- a/to-do/pr-live-tests/run-restore-preview-tests.sh
+++ b/to-do/pr-live-tests/run-restore-preview-tests.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Live + unit tests for restore preview / confirmation PR
+set -uo pipefail
+
+REPO="/home/Github/cyberPanel-repos/cyberpanel"
+LIVE="/usr/local/CyberCP"
+PANEL="${PANEL_URL:-https://127.0.0.1:5003}"
+LOG="$REPO/to-do/pr-live-tests/results-restore-preview-$(date +%Y%m%d-%H%M%S).log"
+FAIL=0
+
+log(){ echo "[$(date '+%H:%M:%S')] $*" | tee -a "$LOG"; }
+pass(){ log "PASS: $*"; }
+fail(){ log "FAIL: $*"; FAIL=1; }
+
+log "=== RESTORE PREVIEW UNIT TESTS ==="
+cd "$LIVE" && PYTHONPATH="$REPO:$LIVE" /usr/local/CyberCP/bin/python "$REPO/backup/test_restore_preview.py" >>"$LOG" 2>&1 && pass "restore preview unit tests" || fail "restore preview unit tests"
+
+log "=== PYTHON SYNTAX ==="
+python3 -m py_compile \
+  "$LIVE/backup/backupManager.py" \
+  "$LIVE/backup/views.py" \
+  "$REPO/backup/test_restore_preview.py" >>"$LOG" 2>&1 \
+  && pass "python syntax" || fail "python syntax"
+
+log "=== LIVE STATIC + TEMPLATE CHECKS ==="
+grep -q 'getBackupFileInfo' "$LIVE/static/backup/backup.js" && pass "live backup.js preview endpoint" || fail "live backup.js preview endpoint"
+grep -q 'openRestoreConfirm' "$LIVE/static/backup/backup.js" && pass "live backup.js confirm modal" || fail "live backup.js confirm modal"
+grep -q 'Review and Restore' "$LIVE/backup/templates/backup/restore.html" && pass "live restore template" || fail "live restore template"
+
+log "=== LIVE API CHECKS (authenticated shell) ==="
+cd "$LIVE" && python3 manage.py shell -c "
+import json
+import os
+from django.test import RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+from loginSystem.models import Administrator
+from backup import views
+
+adm = Administrator.objects.first()
+if not adm:
+    raise SystemExit('no admin user')
+
+backup_dir = '/home/backup'
+files = [f for f in os.listdir(backup_dir) if f.endswith('.tar.gz')]
+if not files:
+    raise SystemExit('no .tar.gz backups in /home/backup for live test')
+sample = files[0]
+
+def post(path, view, payload):
+    rf = RequestFactory()
+    req = rf.post(path, data=json.dumps(payload), content_type='application/json')
+    middleware = SessionMiddleware(lambda r: None)
+    middleware.process_request(req)
+    req.session.save()
+    req.session['userID'] = adm.pk
+    req.session.save()
+    return view(req)
+
+info_resp = post('/backup/getBackupFileInfo', views.getBackupFileInfo, {'backupFile': sample})
+info = json.loads(info_resp.content)
+if info.get('infoStatus') != 1:
+    raise SystemExit('getBackupFileInfo failed: %s' % info)
+if info.get('fileName') != sample:
+    raise SystemExit('unexpected fileName: %s' % info.get('fileName'))
+
+reject_resp = post('/backup/submitRestore', views.submitRestore, {'backupFile': sample})
+reject = json.loads(reject_resp.content)
+if reject.get('restoreStatus') != 0:
+    raise SystemExit('submitRestore without confirm should fail')
+if 'confirmation required' not in reject.get('error_message', '').lower():
+    raise SystemExit('unexpected reject message: %s' % reject.get('error_message'))
+
+print('live restore preview API OK (%s)' % sample)
+" >>"$LOG" 2>&1 && pass "live restore preview API" || fail "live restore preview API"
+
+panel_code=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 15 "$PANEL/backup/restoreSite" || echo 000)
+[[ "$panel_code" =~ ^(200|302)$ ]] && pass "restoreSite route $panel_code" || fail "restoreSite route $panel_code"
+
+log "Log: $LOG"
+exit $FAIL

--- a/to-do/pr-live-tests/run-restore-preview-tests.sh
+++ b/to-do/pr-live-tests/run-restore-preview-tests.sh
@@ -22,7 +22,13 @@ python3 -m py_compile \
   "$REPO/backup/test_restore_preview.py" >>"$LOG" 2>&1 \
   && pass "python syntax" || fail "python syntax"
 
+
+log "=== SYNC PUBLIC STATIC (CyberPanel serves public/static) ==="
+mkdir -p "$LIVE/public/static/backup"
+cp "$LIVE/static/backup/backup.js" "$LIVE/public/static/backup/backup.js"
 log "=== LIVE STATIC + TEMPLATE CHECKS ==="
+grep -q 'getBackupFileInfo' "$LIVE/public/static/backup/backup.js" && pass "public/static backup.js preview endpoint" || fail "public/static backup.js preview endpoint"
+cmp -s "$LIVE/static/backup/backup.js" "$LIVE/public/static/backup/backup.js" && pass "static copies in sync" || fail "static copies differ"
 grep -q 'getBackupFileInfo' "$LIVE/static/backup/backup.js" && pass "live backup.js preview endpoint" || fail "live backup.js preview endpoint"
 grep -q 'openRestoreConfirm' "$LIVE/static/backup/backup.js" && pass "live backup.js confirm modal" || fail "live backup.js confirm modal"
 grep -q 'Review and Restore' "$LIVE/backup/templates/backup/restore.html" && pass "live restore template" || fail "live restore template"


### PR DESCRIPTION
## Summary

- Selecting a backup on `/backup/restoreSite` now loads **preview details only** (file name, size, modified date) via new `/backup/getBackupFileInfo`
- Restore no longer jumps straight into the progress panel on dropdown change
- Added a **Review and Restore** step with a confirmation modal and checkbox before anything runs
- `submitRestore` now requires `confirmed: true`; unconfirmed API calls are rejected server-side

## Why

Restoring the wrong backup from the dropdown is a fatal mistake. The old UI looked like restore had already started when a backup was selected, and the single button had no safety gate.

## Test plan

Ran on live CyberPanel v3.0.5-dev (`https://127.0.0.1:5003`):

```bash
bash to-do/pr-live-tests/run-restore-preview-tests.sh
```

Results (all pass):

- 6 unit tests in `backup/test_restore_preview.py`
- Python syntax on changed backup files
- Live static/template checks for preview + confirm UI
- Live API: `getBackupFileInfo` returns metadata for a real `/home/backup/*.tar.gz`
- Live API: `submitRestore` without `confirmed` is rejected
- `/backup/restoreSite` route responds

Log: `to-do/pr-live-tests/results-restore-preview-20260902-012931.log`

## Files changed

- `backup/backupManager.py` - `getBackupFileInfo()`, confirmation guard on `submitRestore`
- `backup/views.py`, `backup/urls.py` - new route
- `backup/templates/backup/restore.html` - preview card + confirm modal
- `backup/static/backup/backup.js` - preview flow, no restore on dropdown change
- `backup/test_restore_preview.py` - unit tests
- `to-do/pr-live-tests/run-restore-preview-tests.sh` - live test gate